### PR TITLE
Procedure-call Fix.

### DIFF
--- a/lib/plsql/procedure_call.rb
+++ b/lib/plsql/procedure_call.rb
@@ -401,7 +401,7 @@ module PLSQL
       @return_sql << if is_index_by_table
         "i__ := l_#{argument}.FIRST;\nLOOP\nEXIT WHEN i__ IS NULL;\n"
       else
-        "FOR i__ IN l_#{argument}.FIRST..l_#{argument}.LAST LOOP\n"
+        "IF l_#{argument}.COUNT > 0 THEN\nFOR i__ IN l_#{argument}.FIRST..l_#{argument}.LAST LOOP\n"
       end
       case argument_metadata[:element][:data_type]
       when 'PL/SQL RECORD'
@@ -415,6 +415,7 @@ module PLSQL
       end
       @return_sql << "i__ := l_#{argument}.NEXT(i__);\n" if is_index_by_table
       @return_sql << "END LOOP;\n"
+      @return_sql << "END IF;\n" unless is_index_by_table
       @return_sql << "OPEN :#{argument} FOR SELECT #{return_fields_string} FROM #{argument_metadata[:tmp_table_name]} ORDER BY i__;\n"
       @return_sql << "DELETE FROM #{argument_metadata[:tmp_table_name]};\n"
       "l_#{argument} := " if is_return_value


### PR DESCRIPTION
Hi Raymonds,

I fixed a bug in the procedure_call.rb file. It has to do with returning an empty array of records. Without the fix the test will fail with a "ORA-06502: PL/SQL: numeric or value error". This has to do with the fact that first and last gets called on the empty table, but a count check needs to be added first to make it work.

Regards,

Wiehann

-- procedure_call.rb
- Fixed the PL/SQL that gets generated in the add_return_table method to
  first check if the table has any values (by calling
  l_#{argument}.count) before iterating over the table.

-- procedure_spec.rb
- Added a test for this particular bug. A function (test_empty_records)
  is created in the test_record package that returns an empty table of
  employees. It then gets called and should return an empty array.
