### PR TITLE
Correction to ruby_value_to_ora_value when type is OCI8::CLOB in oci_connection.rb

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -194,8 +194,7 @@ module PLSQL
         end
       when :"OCI8::CLOB", :"OCI8::BLOB"
         # ruby-oci8 cannot create CLOB/BLOB from ''
-        value = nil if value == ''
-        type.new(raw_oci_connection, value)
+        value.to_s.length > 0 ? type.new(raw_oci_connection, value) : nil
       when :"OCI8::Cursor"
         value && value.raw_cursor
       else


### PR DESCRIPTION
Raimonds,

Without the one line change the gem does pass and return nil and empty string parameters for procedures and functions, but the value cannot be used to do an insert or update on a table CLOB column. If you try to use the parameter within the procedure or function in an insert statement, Oracle will throw this error: "ORA-22275: invalid LOB locator specified".

By returning nil from ruby_value_to_ora_value when the type is OCI8::CLOB and the value is nil or '' your tests in procedure_spec.rb are still satisfied as well as new tests to make sure that the CLOB parameter can be inserted into a table CLOB column.
