### PR TITLE
Clear global temp tables before populating them with procedure parameters

### DIFF
--- a/lib/plsql/procedure_call.rb
+++ b/lib/plsql/procedure_call.rb
@@ -290,6 +290,7 @@ module PLSQL
       # insert values without autocommit
       old_autocommit = @schema.connection.autocommit?
       @schema.connection.autocommit = false if old_autocommit
+      tmp_table.delete
       case argument_metadata[:element][:data_type]
       when 'PL/SQL RECORD'
         values_with_index = []


### PR DESCRIPTION
Raimonds,

This is the solution to Issue #10 which I entered last October. Here I have added
more testing for the various types of collections that could be passed to a package
procedure.

The global temp tables that hold collection parameters for packages need
to be cleared before they are populated rather than only after the
procedure or function completes. If something goes wrong in the execution
of the Oracle procedure, the global temp table for the parameter will not get
cleared after the call. This leaves behind garbage in the temp table that
will make the subsequent call to the same procedure wrong.

By putting tmp_table.delete right before populating tmp_table there is a
guarantee the no parameters from a previous function call will get passed
on to the current function call.
