### PR TITLE
Support ActiveRecord 3.1, ruby-oci8 OCI8.properties[:length_semantics]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,11 @@ group :development do
   gem 'rspec', '~> 1.3.0'
 
   unless ENV['NO_ACTIVERECORD']
-    # avoid loading activerecord 3.0 beta
-    gem 'activerecord', '=2.3.8'
-    gem 'activerecord-oracle_enhanced-adapter', '=1.3.1'
+    gem 'activerecord'
+    gem 'activerecord-oracle_enhanced-adapter'
   end
 
   if !defined?(RUBY_ENGINE) || RUBY_ENGINE == 'ruby'
-    gem 'ruby-oci8', '>=2.0.4'
+    gem 'ruby-oci8', '~> 2.1.0'
   end
 end

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -56,16 +56,26 @@ describe "Package variables /" do
     end
 
     it "should set and get VARCHAR2(n CHAR) variable" do
+      if OCI8.properties.has_key?(:length_semantics)
+        original_length_semantics = OCI8.properties[:length_semantics]
+        OCI8.properties[:length_semantics] = :char
+      end
       plsql.test_package.varchar2_3_char = 'āčē'
       plsql.test_package.varchar2_3_char.should == 'āčē'
       lambda { plsql.test_package.varchar2_3_char = 'aceg' }.should raise_error(/buffer too small/)
+      OCI8.properties[:length_semantics] = original_length_semantics if OCI8.properties.has_key?(:length_semantics)
     end
 
     it "should set and get VARCHAR2(n BYTE) variable" do
+      if OCI8.properties.has_key?(:length_semantics)
+        original_length_semantics = OCI8.properties[:length_semantics]
+        OCI8.properties[:length_semantics] = :char
+      end
       plsql.test_package.varchar2_3_byte = 'ace'
       plsql.test_package.varchar2_3_byte.should == 'ace'
       lambda { plsql.test_package.varchar2_3_byte = 'āce' }.should raise_error(/buffer too small/)
       lambda { plsql.test_package.varchar2_3_byte = 'aceg' }.should raise_error(/buffer too small/)
+      OCI8.properties[:length_semantics] = original_length_semantics if OCI8.properties.has_key?(:length_semantics)
     end
 
     it "should set and get CHAR variable" do


### PR DESCRIPTION
This pull request supports ActiveRecord 3.1 and ruby-oci8 OCI8.properties [:length_semantics](https://github.com/kubo/ruby-oci8/commit/0bb6cd39c78ea8778d57528d0478a9ac3ced37ba#ext/oci8/bind.c)

Without this commit, rake spec got two failures as follows.

``` ruby
[1.9.3@rubyplsql] yahonda@myoel5 ~/Dropbox/git/ruby-plsql (support_newer_activerecord) 
$ ruby -I"lib:lib:spec"  \
"/home/yahonda/.rvm/gems/ruby-1.8.7-p352/gems/rspec-1.3.2/bin/spec" \
"spec/plsql/variable_spec.rb" 

..............................FF...

1)
ArgumentError in 'Package variables / String should set and get VARCHAR2(n CHAR) variable'
too long String to set. (6 for 3)
/home/yahonda/work/git/ruby-oci8/lib/oci8/bindtype.rb:157:in `set'
/home/yahonda/work/git/ruby-oci8/lib/oci8/bindtype.rb:157:in `initialize'
/home/yahonda/work/git/ruby-oci8/lib/oci8/bindtype.rb:157:in `new'
/home/yahonda/work/git/ruby-oci8/lib/oci8/bindtype.rb:157:in `create'
/home/yahonda/work/git/ruby-oci8/lib/oci8/oci8.rb:624:in `make_bind_object'
/home/yahonda/work/git/ruby-oci8/lib/oci8/oci8.rb:427:in `bind_param'
/home/yahonda/Dropbox/git/ruby-plsql/spec/../lib/plsql/oci_connection.rb:93:in `bind_param'
/home/yahonda/Dropbox/git/ruby-plsql/spec/../lib/plsql/procedure_call.rb:20:in `exec'
/home/yahonda/Dropbox/git/ruby-plsql/spec/../lib/plsql/procedure_call.rb:19:in `each'
/home/yahonda/Dropbox/git/ruby-plsql/spec/../lib/plsql/procedure_call.rb:19:in `exec'
/home/yahonda/Dropbox/git/ruby-plsql/spec/../lib/plsql/variable.rb:42:in `value='
/home/yahonda/Dropbox/git/ruby-plsql/spec/../lib/plsql/package.rb:56:in `method_missing'
./spec/plsql/variable_spec.rb:59:

2)
'Package variables / String should set and get VARCHAR2(n BYTE) variable' FAILED
expected Exception with message matching /buffer too small/, got #<ArgumentError: too long String to set. (4 for 3)>
./spec/plsql/variable_spec.rb:67:

Finished in 1.991699 seconds

35 examples, 2 failures
```
