### PR TITLE
Temporary RUBY_ tables are hanging around in database if exit occurs bef...

### DIFF
--- a/lib/plsql/connection.rb
+++ b/lib/plsql/connection.rb
@@ -7,6 +7,7 @@ module PLSQL
       @raw_driver = self.class.driver_type
       @raw_connection = raw_conn
       @activerecord_class = ar_class
+      ObjectSpace.define_finalizer(self, proc{logoff})
     end
 
     def self.create(raw_conn, ar_class = nil) #:nodoc:


### PR DESCRIPTION
...ore calling logoff. This change enables automatic clean up without needing to use at_exit.
