### PR TITLE
Bumped to ruby-oci8 2.1.2 to work with "should execute function with cursor parameter and return record" 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,5 @@ group :development do
     gem 'activerecord-oracle_enhanced-adapter', '~> 1.4.1'
   end
 
-  # gem 'ruby-oci8', '~> 2.1.0'
-  gem 'ruby-oci8', :git => 'git://github.com/kubo/ruby-oci8.git', :platforms => :mri
+  gem 'ruby-oci8', '~> 2.1.2'
 end

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -1814,7 +1814,6 @@ describe "Parameter type mapping /" do
 
     it "should execute function with cursor parameter and return record" do
       pending "not possible from JDBC" if defined?(JRUBY_VERSION)
-      pending "fails with core dump with ruby-oci8 2.1.0" if OCI8::VERSION >= "2.1.0"
       plsql.test_cursor do |cursor|
         plsql.test_cursor_fetch(cursor).should == @employees[0]
       end


### PR DESCRIPTION
Issue #21 has been resolved by ruby-oci8 2.1.2
