### PR TITLE
pass LoadError original message when ruby-oci8 is installed.

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -2,7 +2,16 @@ begin
   require "oci8"
 rescue LoadError
   # OCI8 driver is unavailable.
-  raise LoadError, "ERROR: ruby-plsql could not load ruby-oci8 library. Please install ruby-oci8 gem."
+  msg = $!.to_s
+  if /-- oci8$/ =~ msg
+    # ruby-oci8 is not installed.
+    # MRI <= 1.9.2, Rubinius, JRuby:
+    #   no such file to load -- oci8
+    # MRI >= 1.9.3:
+    #   cannot load such file -- oci8
+    msg = "Please install ruby-oci8 gem."
+  end
+  raise LoadError, "ERROR: ruby-plsql could not load ruby-oci8 library. #{msg}"
 end
 
 require "plsql/oci8_patches"


### PR DESCRIPTION
When ruby-oci8 is installed and libaio1 is not installed on Ubuntu, "require 'oci8'" raises
a LoadError: "libaio.so.1: cannot open shared object file: ..."
But ruby-plsql ignores the message and raises a LoadError: "ERROR: ruby-plsql could not load ruby-oci8 library. Please install ruby-oci8 gem." It is hard to know the LoadError's reason.
This pull request makes it easy.

See kubo/ruby-oci8#14
