### PR TITLE
PLSQL::Package#procedure_defined? to test whether a given procedure is available

### DIFF
--- a/lib/plsql/package.rb
+++ b/lib/plsql/package.rb
@@ -37,6 +37,10 @@ module PLSQL
       @package_objects = {}
     end
 
+    def procedure_defined?(name)
+      PLSQL::Procedure.find(@schema, name, @package) ? true : false
+    end
+
     private
     
     def method_missing(method, *args, &block)

--- a/spec/plsql/package_spec.rb
+++ b/spec/plsql/package_spec.rb
@@ -47,6 +47,14 @@ describe "Package" do
     plsql.test_package.test_procedure('xxx').should == 'XXX'
   end
 
+  it "should report an existing procedure as existing" do
+    plsql.test_package.procedure_defined?(:test_procedure).should == true
+  end
+
+  it "should report an inexistent procedure as not existing" do
+    plsql.test_package.procedure_defined?(:inexistent_procedure).should == false
+  end
+
   describe "variables" do
     it "should set and get package variable value" do
       plsql.test_package.test_variable = 1


### PR DESCRIPTION
My use case is a slow migration where some procedure names change. I update the code to test whether the new procedure is already available and if not still uses the old name.
I hope you find this method useful to include it in ruby-plsql.