### PR TITLE
fix package procedure object_id retrieval

### DIFF
--- a/lib/plsql/schema.rb
+++ b/lib/plsql/schema.rb
@@ -210,6 +210,15 @@ module PLSQL
           _errors(object_schema_name, object_name, 'PACKAGE BODY')}" if body_status == 'INVALID'
         case object_type
         when 'PROCEDURE', 'FUNCTION'
+          if (connection.database_version <=> [11, 1, 0, 0]) >= 0
+            row = select_first(
+              "SELECT p.object_id FROM all_procedures p
+               WHERE p.owner = :owner
+                 AND p.object_name = :object_name
+                 AND p.object_type = :object_type",
+               object_schema_name, object_name, object_type)
+            object_id = row[0]
+          end
           Procedure.new(self, name, nil, override_schema_name, object_id)
         when 'PACKAGE'
           Package.new(self, name, override_schema_name)


### PR DESCRIPTION
In Oracle 12c (maybe 11g too but I haven't checked it) the object_id for a package procedure is not the same in all_procedures and all_objects. Without this fix the package spec was failing since `all_arguments` is based on the id of `*_all_procedures`.

Here is an example from a 12.1.0.2 environment:

``` sql
SQL> SELECT p.object_id p_obj_id, o.object_id o_obj_id
FROM all_procedures p, all_objects o
WHERE p.owner = 'SYS'
  AND p.object_name = 'UTL_ENCODE'
  AND p.procedure_name = 'BASE64_ENCODE'
  AND o.owner = p.owner
  AND o.object_name = p.object_name
  AND o.object_type = 'PACKAGE';

  P_OBJ_ID   O_OBJ_ID
---------- ----------
     11418  11416

1 row selected.
```
