### PR TITLE
jruby: allow connection by service name

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -39,10 +39,12 @@ module PLSQL
   class JDBCConnection < Connection  #:nodoc:
 
     def self.create_raw(params)
-      url = if ENV['TNS_ADMIN'] && params[:database] && !params[:host] && !params[:url]
-        "jdbc:oracle:thin:@#{params[:database]}"
+      database = params[:database]
+      url = if ENV['TNS_ADMIN'] && database && !params[:host] && !params[:url]
+        "jdbc:oracle:thin:@#{database}"
       else
-        params[:url] || "jdbc:oracle:thin:@#{params[:host] || 'localhost'}:#{params[:port] || 1521}:#{params[:database]}"
+        database = ":#{database}" unless database.match(/^(\:|\/)/)
+        params[:url] || "jdbc:oracle:thin:@#{params[:host] || 'localhost'}:#{params[:port] || 1521}#{database}"
       end
       new(java.sql.DriverManager.getConnection(url, params[:username], params[:password]))
     end

--- a/lib/plsql/schema.rb
+++ b/lib/plsql/schema.rb
@@ -41,7 +41,7 @@ module PLSQL
     # or
     #
     #   plsql.connection = java.sql.DriverManager.getConnection(
-    #     "jdbc:oracle:thin:@#{database_host}:#{database_port}:#{database_name}",
+    #     "jdbc:oracle:thin:@#{database_host}:#{database_port}/#{database_service_name}",
     #     database_user, database_password)
     #
     def connection=(conn)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,8 @@ end
 require 'ruby-plsql'
 
 DATABASE_NAME = ENV['DATABASE_NAME'] || 'orcl'
-DATABASE_SERVICE_NAME = ENV['DATABASE_SERVICE_NAME'] || DATABASE_NAME
+DATABASE_SERVICE_NAME = (defined?(JRUBY_VERSION) ? "/" : "") +
+                        (ENV['DATABASE_SERVICE_NAME'] || DATABASE_NAME)
 DATABASE_HOST = ENV['DATABASE_HOST'] || 'localhost'
 DATABASE_PORT = (ENV['DATABASE_PORT'] || 1521).to_i
 DATABASE_USERS_AND_PASSWORDS = [
@@ -33,7 +34,7 @@ def get_connection(user_number = 0)
     end
   else
     try_to_connect(NativeException) do
-      java.sql.DriverManager.getConnection("jdbc:oracle:thin:@#{DATABASE_HOST}:#{DATABASE_PORT}:#{DATABASE_NAME}",
+      java.sql.DriverManager.getConnection("jdbc:oracle:thin:@#{DATABASE_HOST}:#{DATABASE_PORT}#{DATABASE_SERVICE_NAME}",
         database_user, database_password)
     end
   end


### PR DESCRIPTION
- [x] Allow JDBC connections (when using JRUBY) by service name (used to be by SID only). The database parameter syntax is like in oracle advanced adapter: prefix "/" means connection by _service name_.
- [x] Use service name connection in tests with jruby. (This complements #55 which took care about MRI ruby).
