### PR TITLE
migrate from rcov to simplecov for tests coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   unless ENV['NO_ACTIVERECORD']
     gem 'activerecord', '>= 3.2.3', '< 4.2.0'
     gem 'activerecord-oracle_enhanced-adapter', '>= 1.4.1', '< 1.6.0'
+    gem 'simplecov', '>= 0'
   end
 
   platforms :ruby do

--- a/Rakefile
+++ b/Rakefile
@@ -29,9 +29,10 @@ Jeweler::RubygemsDotOrgTasks.new
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
-RSpec::Core::RakeTask.new(:rcov) do |t|
-  t.rcov = true
-  t.rcov_opts =  ['--exclude', '/Library,spec/']
+desc "Code coverage detail"
+task :simplecov do
+  ENV['COVERAGE'] = "true"
+  Rake::Task['spec'].execute
 end
 
 task :default => :spec

--- a/ruby-plsql.gemspec
+++ b/ruby-plsql.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Raimonds Simanovskis"]
-  s.date = "2014-10-04"
+  s.date = "2014-10-05"
   s.description = "ruby-plsql gem provides simple Ruby API for calling Oracle PL/SQL procedures.\nIt could be used both for accessing Oracle PL/SQL API procedures in legacy applications\nas well as it could be used to create PL/SQL unit tests using Ruby testing libraries.\n"
   s.email = "raimonds.simanovskis@gmail.com"
   s.extra_rdoc_files = [
@@ -69,12 +69,14 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>, ["~> 3.1"])
       s.add_development_dependency(%q<activerecord>, ["< 4.2.0", ">= 3.2.3"])
       s.add_development_dependency(%q<activerecord-oracle_enhanced-adapter>, ["< 1.6.0", ">= 1.4.1"])
+      s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<ruby-oci8>, ["~> 2.1.2"])
     else
       s.add_dependency(%q<jeweler>, ["~> 2.0.1"])
       s.add_dependency(%q<rspec>, ["~> 3.1"])
       s.add_dependency(%q<activerecord>, ["< 4.2.0", ">= 3.2.3"])
       s.add_dependency(%q<activerecord-oracle_enhanced-adapter>, ["< 1.6.0", ">= 1.4.1"])
+      s.add_dependency(%q<simplecov>, [">= 0"])
       s.add_dependency(%q<ruby-oci8>, ["~> 2.1.2"])
     end
   else
@@ -82,6 +84,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rspec>, ["~> 3.1"])
     s.add_dependency(%q<activerecord>, ["< 4.2.0", ">= 3.2.3"])
     s.add_dependency(%q<activerecord-oracle_enhanced-adapter>, ["< 1.6.0", ">= 1.4.1"])
+    s.add_dependency(%q<simplecov>, [">= 0"])
     s.add_dependency(%q<ruby-oci8>, ["~> 2.1.2"])
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,18 @@
 require "rubygems"
 require "bundler"
 Bundler.setup(:default, :development)
+require 'simplecov'
 
-$:.unshift(File.dirname(__FILE__) + '/../lib')
+SimpleCov.configure do
+  load_profile 'root_filter'
+  load_profile 'test_frameworks'
+end
 
+ENV["COVERAGE"] && SimpleCov.start do
+  add_filter "/.rvm/"
+end
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'rspec'
 
 unless ENV['NO_ACTIVERECORD']


### PR DESCRIPTION
Migrate from rcov to simplecov for tests coverage

rcov is not supported on ruby 1.9.x and higher
