### PR TITLE
Force to convert String type value as real string to avoid 'no method se...

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -109,14 +109,14 @@ module PLSQL
           @out_types[arg] = type || ora_value.class
           @out_index[arg] = bind_param_index(arg)
           if ['TABLE','VARRAY','OBJECT'].include?(metadata[:data_type])
-            @statement.registerOutParameter(@out_index[arg], @connection.get_java_sql_type(ora_value,type),
+            @statement.registerOutParameter(@out_index[arg], @connection.get_java_sql_type(ora_value,type), 
               metadata[:sql_type_name])
           else
             @statement.registerOutParameter(@out_index[arg],@connection.get_java_sql_type(ora_value,type))
           end
         end
       end
-
+      
       def exec
         @statement.execute
       end
@@ -130,7 +130,7 @@ module PLSQL
       end
 
       private
-
+      
       def bind_param_index(key)
         return key if key.kind_of? Integer
         key = ":#{key.to_s}" unless key.to_s =~ /^:/
@@ -301,7 +301,7 @@ module PLSQL
         raise ArgumentError, "Don't know how to bind variable with type #{type_symbol}"
       end
     end
-
+    
     def get_bind_variable(stmt, i, type)
       case type.to_s.to_sym
       when :Fixnum, :Bignum, :Integer
@@ -337,7 +337,7 @@ module PLSQL
     end
 
     def result_set_to_ruby_data_type(column_type, column_type_name)
-
+      
     end
 
     def plsql_to_ruby_data_type(metadata)
@@ -521,7 +521,7 @@ module PLSQL
         [major, minor, update, patch]
       end
     end
-
+    
     private
 
     def java_date(value)
@@ -540,7 +540,7 @@ module PLSQL
       # return BigDecimal instead of Float to avoid rounding errors
       num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal.new(num.to_s))
     end
-
+    
   end
-
+  
 end

--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -128,7 +128,7 @@ module PLSQL
       def close
         @statement.close
       end
-
+      
       private
       
       def bind_param_index(key)

--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -109,14 +109,14 @@ module PLSQL
           @out_types[arg] = type || ora_value.class
           @out_index[arg] = bind_param_index(arg)
           if ['TABLE','VARRAY','OBJECT'].include?(metadata[:data_type])
-            @statement.registerOutParameter(@out_index[arg], @connection.get_java_sql_type(ora_value,type), 
+            @statement.registerOutParameter(@out_index[arg], @connection.get_java_sql_type(ora_value,type),
               metadata[:sql_type_name])
           else
             @statement.registerOutParameter(@out_index[arg],@connection.get_java_sql_type(ora_value,type))
           end
         end
       end
-      
+
       def exec
         @statement.execute
       end
@@ -128,9 +128,9 @@ module PLSQL
       def close
         @statement.close
       end
-      
+
       private
-      
+
       def bind_param_index(key)
         return key if key.kind_of? Integer
         key = ":#{key.to_s}" unless key.to_s =~ /^:/
@@ -301,7 +301,7 @@ module PLSQL
         raise ArgumentError, "Don't know how to bind variable with type #{type_symbol}"
       end
     end
-    
+
     def get_bind_variable(stmt, i, type)
       case type.to_s.to_sym
       when :Fixnum, :Bignum, :Integer
@@ -337,7 +337,7 @@ module PLSQL
     end
 
     def result_set_to_ruby_data_type(column_type, column_type_name)
-      
+
     end
 
     def plsql_to_ruby_data_type(metadata)
@@ -371,8 +371,10 @@ module PLSQL
     def ruby_value_to_ora_value(value, type=nil, metadata={})
       type ||= value.class
       case type.to_s.to_sym
-      when :Fixnum, :String
+      when :Fixnum
         value
+      when :String
+        value.to_s
       when :BigDecimal
         case value
         when TrueClass
@@ -521,7 +523,7 @@ module PLSQL
     end
 
     private
-    
+
     def java_date(value)
       value && Java::oracle.sql.DATE.new(value.strftime("%Y-%m-%d %H:%M:%S"))
     end
@@ -538,7 +540,7 @@ module PLSQL
       # return BigDecimal instead of Float to avoid rounding errors
       num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal.new(num.to_s))
     end
-    
+
   end
-  
+
 end

--- a/spec/plsql/connection_spec.rb
+++ b/spec/plsql/connection_spec.rb
@@ -145,7 +145,7 @@ describe "Connection" do
         expect(@conn.ruby_value_to_ora_value(100, BigDecimal)).to eq java.math.BigDecimal.new(100)
       end
 
-      it "should translate Ruby String to sting value" do
+      it "should translate Ruby String to string value" do
         expect(@conn.ruby_value_to_ora_value(1.1, String)).to eq '1.1'
       end
 

--- a/spec/plsql/connection_spec.rb
+++ b/spec/plsql/connection_spec.rb
@@ -117,7 +117,7 @@ describe "Connection" do
         clob = OCI8::CLOB.new(@raw_conn, large_text)
         expect(@conn.ora_value_to_ruby_value(clob)).to eq large_text
       end
-
+      
     end
 
   # JRuby
@@ -132,15 +132,15 @@ describe "Connection" do
       it "should translate PL/SQL NUMBER to Ruby BigDecimal" do
         expect(@conn.plsql_to_ruby_data_type(:data_type => "NUMBER", :data_length => 15)).to eq [BigDecimal, nil]
       end
-
+      
       it "should translate PL/SQL DATE to Ruby DateTime" do
         expect(@conn.plsql_to_ruby_data_type(:data_type => "DATE", :data_length => nil)).to eq [DateTime, nil]
       end
-
+      
       it "should translate PL/SQL TIMESTAMP to Ruby Time" do
         expect(@conn.plsql_to_ruby_data_type(:data_type => "TIMESTAMP", :data_length => nil)).to eq [Time, nil]
       end
-
+      
       it "should not translate Ruby Fixnum when BigDecimal type specified" do
         expect(@conn.ruby_value_to_ora_value(100, BigDecimal)).to eq java.math.BigDecimal.new(100)
       end
@@ -171,7 +171,7 @@ describe "Connection" do
       it "should translate Oracle BigDecimal integer value to Fixnum" do
         expect(@conn.ora_value_to_ruby_value(BigDecimal("100"))).to eql(100)
       end
-
+      
       it "should translate Oracle BigDecimal float value to BigDecimal" do
         expect(@conn.ora_value_to_ruby_value(BigDecimal("100.11"))).to eql(BigDecimal("100.11"))
       end
@@ -214,7 +214,7 @@ describe "Connection" do
       expect(@conn.select_first("SELECT :1,:2,:3,:4,:5 FROM dual",
         'abc',123,123.456,@now,@today)).to eq ["abc",123,123.456,@now,Time.parse(@today.to_s)]
     end
-
+    
     it "should execute SQL statement with NULL values and return first result" do
       @now = Time.local(2008,05,31,23,22,11)
       expect(@conn.select_first("SELECT NULL,123,123.456,
@@ -230,7 +230,7 @@ describe "Connection" do
         expect(@conn.select_first("SELECT :1,:2,:3,:4,:5 FROM dual",
           nil,123,123.456,@now,@today)).to eq [nil,123,123.456,@now,Time.parse(@today.to_s)]
       end
-
+    
     end
 
     it "should execute SQL statement and return all results" do
@@ -270,7 +270,7 @@ describe "Connection" do
         expect(r).to eq ["abc",123,123.456,@now]
       end).to eq 2
     end
-
+    
     it "should execute SQL statement with bind parameters and yield all results in block" do
       @now = Time.local(2008,05,31,23,22,11)
       expect(@conn.select_all("SELECT :1,:2,:3,:4 FROM dual UNION ALL SELECT :1,:2,:3,:4 FROM dual",
@@ -280,7 +280,7 @@ describe "Connection" do
     end
 
   end
-
+  
   describe "PL/SQL procedures" do
     before(:all) do
       @random = rand(1000)
@@ -317,9 +317,9 @@ describe "Connection" do
       expect(cursor[":p_date"]).to eq @now
       expect(cursor.close).to be_nil
     end
-
+  
   end
-
+  
   describe "commit and rollback" do
     before(:all) do
       expect(@conn.exec("CREATE TABLE test_commit (dummy VARCHAR2(100))")).to be true

--- a/spec/plsql/connection_spec.rb
+++ b/spec/plsql/connection_spec.rb
@@ -258,7 +258,7 @@ describe "Connection" do
       expect(@conn.select_all("SELECT :1,:2,:3,:4 FROM dual UNION ALL SELECT :1,:2,:3,:4 FROM dual",
         'abc',123,123.456,@now,'abc',123,123.456,@now)).to eq [["abc",123,123.456,@now],["abc",123,123.456,@now]]
     end
-
+    
     it "should execute SQL statement and yield all results in block" do
       @now = Time.local(2008,05,31,23,22,11)
       expect(@conn.select_all("SELECT 'abc',123,123.456,

--- a/spec/plsql/connection_spec.rb
+++ b/spec/plsql/connection_spec.rb
@@ -117,7 +117,7 @@ describe "Connection" do
         clob = OCI8::CLOB.new(@raw_conn, large_text)
         expect(@conn.ora_value_to_ruby_value(clob)).to eq large_text
       end
-      
+
     end
 
   # JRuby
@@ -132,19 +132,23 @@ describe "Connection" do
       it "should translate PL/SQL NUMBER to Ruby BigDecimal" do
         expect(@conn.plsql_to_ruby_data_type(:data_type => "NUMBER", :data_length => 15)).to eq [BigDecimal, nil]
       end
-      
+
       it "should translate PL/SQL DATE to Ruby DateTime" do
         expect(@conn.plsql_to_ruby_data_type(:data_type => "DATE", :data_length => nil)).to eq [DateTime, nil]
       end
-      
+
       it "should translate PL/SQL TIMESTAMP to Ruby Time" do
         expect(@conn.plsql_to_ruby_data_type(:data_type => "TIMESTAMP", :data_length => nil)).to eq [Time, nil]
       end
-      
+
       it "should not translate Ruby Fixnum when BigDecimal type specified" do
         expect(@conn.ruby_value_to_ora_value(100, BigDecimal)).to eq java.math.BigDecimal.new(100)
       end
-      
+
+      it "should translate Ruby String to sting value" do
+        expect(@conn.ruby_value_to_ora_value(1.1, String)).to eq '1.1'
+      end
+
       it "should translate Ruby Bignum value to BigDecimal when BigDecimal type specified" do
         big_decimal = @conn.ruby_value_to_ora_value(12345678901234567890, BigDecimal)
         expect(big_decimal).to eq java.math.BigDecimal.new("12345678901234567890")
@@ -167,7 +171,7 @@ describe "Connection" do
       it "should translate Oracle BigDecimal integer value to Fixnum" do
         expect(@conn.ora_value_to_ruby_value(BigDecimal("100"))).to eql(100)
       end
-      
+
       it "should translate Oracle BigDecimal float value to BigDecimal" do
         expect(@conn.ora_value_to_ruby_value(BigDecimal("100.11"))).to eql(BigDecimal("100.11"))
       end
@@ -210,7 +214,7 @@ describe "Connection" do
       expect(@conn.select_first("SELECT :1,:2,:3,:4,:5 FROM dual",
         'abc',123,123.456,@now,@today)).to eq ["abc",123,123.456,@now,Time.parse(@today.to_s)]
     end
-    
+
     it "should execute SQL statement with NULL values and return first result" do
       @now = Time.local(2008,05,31,23,22,11)
       expect(@conn.select_first("SELECT NULL,123,123.456,
@@ -226,7 +230,7 @@ describe "Connection" do
         expect(@conn.select_first("SELECT :1,:2,:3,:4,:5 FROM dual",
           nil,123,123.456,@now,@today)).to eq [nil,123,123.456,@now,Time.parse(@today.to_s)]
       end
-    
+
     end
 
     it "should execute SQL statement and return all results" do
@@ -254,7 +258,7 @@ describe "Connection" do
       expect(@conn.select_all("SELECT :1,:2,:3,:4 FROM dual UNION ALL SELECT :1,:2,:3,:4 FROM dual",
         'abc',123,123.456,@now,'abc',123,123.456,@now)).to eq [["abc",123,123.456,@now],["abc",123,123.456,@now]]
     end
-    
+
     it "should execute SQL statement and yield all results in block" do
       @now = Time.local(2008,05,31,23,22,11)
       expect(@conn.select_all("SELECT 'abc',123,123.456,
@@ -266,7 +270,7 @@ describe "Connection" do
         expect(r).to eq ["abc",123,123.456,@now]
       end).to eq 2
     end
-    
+
     it "should execute SQL statement with bind parameters and yield all results in block" do
       @now = Time.local(2008,05,31,23,22,11)
       expect(@conn.select_all("SELECT :1,:2,:3,:4 FROM dual UNION ALL SELECT :1,:2,:3,:4 FROM dual",
@@ -276,7 +280,7 @@ describe "Connection" do
     end
 
   end
-  
+
   describe "PL/SQL procedures" do
     before(:all) do
       @random = rand(1000)
@@ -313,9 +317,9 @@ describe "Connection" do
       expect(cursor[":p_date"]).to eq @now
       expect(cursor.close).to be_nil
     end
-  
+
   end
-  
+
   describe "commit and rollback" do
     before(:all) do
       expect(@conn.exec("CREATE TABLE test_commit (dummy VARCHAR2(100))")).to be true


### PR DESCRIPTION
Force to convert String type value as real string to avoid error when used JRuby and for VARCHAR2 parameter is assigned non String value

Here is error stack trace what was fixed
```ruby
no method 'setStringAtName' for arguments (org.jruby.RubyString,org.jruby.RubyFloat) on Java::OracleJdbcDriver::OracleCallableStatementWrapper
  available overloads:
    (java.lang.String,java.lang.String)
    (java.lang.String,java.lang.String) (NameError)
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/jdbc_connection.rb:271:in `set_bind_variable'
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/jdbc_connection.rb:107:in `bind_param'
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/procedure_call.rb:20:in `exec'
org/jruby/RubyHash.java:1339:in `each'
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/procedure_call.rb:19:in `exec'
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/table.rb:179:in `insert'
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/table.rb:171:in `insert'
org/jruby/RubyArray.java:1613:in `each'
/.rvm/gems/jruby-1.7.11@myjava_api/bundler/gems/ruby-plsql-f4e5e57566dd/lib/plsql/table.rb:171:in `insert'
```