### PR TITLE
Fix dbms output in case of exception

### DIFF
--- a/lib/plsql/procedure_call.rb
+++ b/lib/plsql/procedure_call.rb
@@ -26,8 +26,6 @@ module PLSQL
 
       @cursor.exec
 
-      dbms_output_log
-
       if block_given?
         yield get_return_value
         nil
@@ -36,6 +34,7 @@ module PLSQL
       end
     ensure
       @cursor.close if @cursor
+      dbms_output_log
     end
 
     private

--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -227,10 +227,13 @@ describe "DBMS_OUTPUT logging" do
   before(:all) do
     plsql.connection = get_connection
     plsql.execute <<-SQL
-      CREATE OR REPLACE PROCEDURE test_dbms_output(p_string VARCHAR2)
+      CREATE OR REPLACE PROCEDURE test_dbms_output(p_string VARCHAR2, p_raise_error BOOLEAN := false)
       IS
       BEGIN
         DBMS_OUTPUT.PUT_LINE(p_string);
+        IF p_raise_error THEN
+          RAISE_APPLICATION_ERROR(-20000 - 12, 'Test Error');
+        END IF;
       END;
     SQL
     plsql.execute <<-SQL
@@ -269,6 +272,11 @@ describe "DBMS_OUTPUT logging" do
 
     it "should log output to specified stream" do
       plsql.test_dbms_output("test_dbms_output")
+      expect(@buffer.string).to eq("DBMS_OUTPUT: test_dbms_output\n")
+    end
+
+    it "should log output to specified stream in case of exception" do
+      expect { plsql.test_dbms_output("test_dbms_output", true) }.to raise_error /Test Error/
       expect(@buffer.string).to eq("DBMS_OUTPUT: test_dbms_output\n")
     end
 


### PR DESCRIPTION
Fix for the following issue: dbms_output logging didn't work properly when the database call failed with exception: it was suppressed for the failing call and was displayed with the next (successful) call.
    
Fixed by moving dbms output logging to the `ensure` section.
