### PR TITLE
extend supported activerecord versions to 4.2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ group :development do
   gem 'rspec', '~> 3.1'
 
   unless ENV['NO_ACTIVERECORD']
-    gem 'activerecord', '>= 3.2.3', '< 4.2.0'
+    gem 'activerecord', '>= 3.2.3', '< 4.3.0'
     gem 'activerecord-oracle_enhanced-adapter', '>= 1.4.1', '< 1.6.0'
     gem 'simplecov', '>= 0'
   end


### PR DESCRIPTION
Bumping up activerecord versions range to 4.2.x (tests are passing OK)