### PR TITLE
Fix thread safety problem in PLSQL::OCIConnection::Cursor

### DIFF
--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -220,6 +220,15 @@ describe "ActiveRecord connection" do
     plsql.activerecord_class = TestModel
     expect(plsql.schema_name).to eq('HR')
   end
+
+  it "should safely close cursors in threaded environment" do
+    expect {
+      t1 = Thread.new { plsql.dbms_lock.sleep(1) }.tap { |t| t.abort_on_exception = true }
+      t2 = Thread.new { plsql.dbms_lock.sleep(2) }.tap { |t| t.abort_on_exception = true }
+      [t2, t1].each { |t| t.join }
+    }.not_to raise_error
+  end
+
 end if defined?(ActiveRecord)
 
 describe "DBMS_OUTPUT logging" do


### PR DESCRIPTION
This is intended to resolve #46 (small fix up on top of the original proposal)

Problem occurred in multithreaded environment with shared state (class variable): OCIException: OCI8::Cursor was already closed.

* Fixed by maintaining separate stack of open cursors per thread

* Original solution by
  Author:    Nikita Shilnikov
  Date:      Fri Mar 1 02:31:16 2013 +0400
  commit:    d363756aff95d77fd810e59383874b1289bc42a7
  source:    github.com flash-gordon/ruby-plsql oci_ar_threaded_fix

* Later amended to use Thread.current in order to avoid memory leaks