### PR TITLE
Oracle implicitly recompiles invalid objects

### DIFF
--- a/lib/plsql/schema.rb
+++ b/lib/plsql/schema.rb
@@ -204,10 +204,6 @@ module PLSQL
           AND object_type IN ('PROCEDURE','FUNCTION','PACKAGE','TABLE','VIEW','SEQUENCE','TYPE','SYNONYM')",
           object_schema_name, object_name)
         object_type, object_id, status, body_status = row
-        raise ArgumentError, "Database object '#{object_schema_name}.#{object_name}' is not in valid status\n#{
-          _errors(object_schema_name, object_name, object_type)}" if status == 'INVALID'
-        raise ArgumentError, "Package '#{object_schema_name}.#{object_name}' body is not in valid status\n#{
-          _errors(object_schema_name, object_name, 'PACKAGE BODY')}" if body_status == 'INVALID'
         case object_type
         when 'PROCEDURE', 'FUNCTION'
           if (connection.database_version <=> [11, 1, 0, 0]) >= 0


### PR DESCRIPTION
If any object that is referenced within a package, package body, function, procedure, view, etc. is modified, that package, package body, etc. is invalid and must be recompiled.

Oracle attempts to recompile invalid objects at the time of execution.

It is counterproductive to throw an error before attempting to execute a statement containing an object with a status of invalid.

Now, an object that would recompile successfully - recompiles and executes. An object that will not recompile successfully, throws an OCI8 error containing the Oracle error that would be helpful when troubleshooting an invalid object.
