### PR TITLE
Changed ruby_value_to_ora_value to not fail when supplied with an SDO object

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/centos-6.6"
+  config.vm.box = "bento/centos-6.7"
   config.vm.hostname = "vagrant.oracle"
   config.vm.network :forwarded_port, guest: 1521, host: 1521
 

--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -47,7 +47,7 @@ module PLSQL
     def rollback
       raw_connection.rollback
     end
-    
+
     def autocommit?
       raw_connection.autocommit?
     end
@@ -104,7 +104,7 @@ module PLSQL
         ora_value = @connection.ruby_value_to_ora_value(value, type)
         @raw_cursor.bind_param(arg, ora_value, type, length)
       end
-      
+
       def exec(*bindvars)
         @raw_cursor.exec(*bindvars)
       end
@@ -297,12 +297,12 @@ module PLSQL
     end
 
     def database_version
-      @database_version ||= (version = raw_connection.oracle_server_version) && 
+      @database_version ||= (version = raw_connection.oracle_server_version) &&
         [version.major, version.minor, version.update, version.patch]
     end
 
     private
-    
+
     def raw_oci_connection
       if raw_connection.is_a? OCI8
         raw_connection
@@ -312,12 +312,12 @@ module PLSQL
         raw_connection.instance_variable_get(:@connection)
       end
     end
-    
+
     def ora_number_to_ruby_number(num)
       # return BigDecimal instead of Float to avoid rounding errors
       num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal.new(num.to_s))
     end
-    
+
     def ora_date_to_ruby_date(val)
       case val
       when DateTime
@@ -342,18 +342,5 @@ module PLSQL
     end
 
   end
-  
-end
 
-
-module OCI8::Object::Mdsys
-  class SdoPointType < OCI8::Object::Base
-  end
-  class SdoElemInfoArray < OCI8::Object::Base
-  end
-  class SdoOrdinateArray < OCI8::Object::Base
-  end
-  class SdoGeometry < OCI8::Object::Base
-    set_typename('MDSYS.SDO_GEOMETRY')
-  end
 end

--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -229,6 +229,9 @@ module PLSQL
             collection = type.new(raw_oci_connection)
             collection.instance_variable_set('@attributes', elem_list)
             collection
+          elsif value.class == type
+            # already an instance of the required type
+            value
           else # object type
             raise ArgumentError, "You should pass Hash value for object type parameter" unless value.is_a?(Hash)
             object_attrs = value.dup

--- a/spec/plsql/spatial_spec.rb
+++ b/spec/plsql/spatial_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe "Spatial" do
+  before(:all) do
+    # plsql.connect! CONNECTION_PARAMS
+    @connection = OCI8.new('hr','hr','//localhost:1521/XE') # TODO use CONNECTION_PARAMS
+    plsql.connection = @connection
+    plsql.connection.autocommit = false
+    plsql.execute <<-SQL
+      CREATE TABLE test_spatial (
+        geom   MDSYS.SDO_GEOMETRY
+      )
+    SQL
+
+    @insert_row_2d_polygon_sql = <<-SQL
+      insert into test_spatial(geom) values (
+        SDO_GEOMETRY(
+          2003,
+          27700,
+          NULL,
+          SDO_ELEM_INFO_ARRAY(1, 1003, 1),
+          SDO_ORDINATE_ARRAY(2, 1, 4, 1, 4, 6, 2, 6, 2, 1)
+        )
+      )
+  SQL
+    @insert_row_2d_point_sql = <<-SQL
+      insert into test_spatial(geom) values (
+        SDO_GEOMETRY(
+          2001,
+          NULL,
+          SDO_POINT_TYPE(12, 14, NULL),
+          NULL,
+          NULL
+        )
+      )
+  SQL
+  end
+
+  after(:all) do
+    plsql.execute "DROP TABLE test_spatial"
+    plsql.logoff
+  end
+
+  after(:each) do
+    plsql.rollback
+  end
+
+  describe "table" do
+    it "should be able to use the cursor's geometry" do
+      puts "number of rows before: #{plsql.test_spatial.count}"
+      geom = make_geometry(2003, 27700, nil, [1, 1003, 1], [2, 1, 4, 1, 4, 6, 2, 6, 2, 1])
+      plsql.test_spatial.insert({:geom=>geom})
+      expect(plsql.test_spatial.first).to eq({:geom=>{:sdo_gtype=>2003, :sdo_srid=>27700, :sdo_point=>nil, :sdo_elem_info=>[1, 1003, 1], :sdo_ordinates=>[2, 1, 4, 1, 4, 6, 2, 6, 2, 1]}})
+    end
+    # xit "should be able to create a geometry that can be used in an insert statement" do
+    #   geom = plsql.sdo_geometry({:sdo_gtype=>2001, :sdo_srid=>nil, :sdo_point=>{:x=>12, :y=>14, :z=>nil}, :sdo_elem_info=>nil, :sdo_ordinates=>nil})
+    #   plsql.test_spatial.insert({:geom=>geom})
+    # end
+    # xit "should select a polygon from a table" do
+    #   plsql.execute @insert_row_2d_polygon_sql
+    #   expect(plsql.test_spatial.first).to eq({:geom=>{:sdo_gtype=>2003, :sdo_srid=>27700, :sdo_point=>nil, :sdo_elem_info=>[1, 1003, 1], :sdo_ordinates=>[2, 1, 4, 1, 4, 6, 2, 6, 2, 1]}})
+    # end
+    # xit "should select a point from a table" do
+    #   plsql.execute @insert_row_2d_point_sql
+    #   expect(plsql.test_spatial.first).to eq({:geom=>{:sdo_gtype=>2001, :sdo_srid=>nil, :sdo_point=>{:x=>12, :y=>14, :z=>nil}, :sdo_elem_info=>nil, :sdo_ordinates=>nil}})
+    # end
+    # xit "should insert a row" do
+    #   plsql.test_spatial.insert({:geom=>{:sdo_gtype=>2001, :sdo_srid=>nil, :sdo_point=>{:x=>12, :y=>14, :z=>nil}, :sdo_elem_info=>nil, :sdo_ordinates=>nil}})
+    # end
+  end
+end
+
+def make_geometry(gtype, srid, sdo_point, sdo_elem_info_array, sdo_ordinate_array)
+  # based on some of the logic from http://stackoverflow.com/a/11323760
+  local_cursor = @connection.parse <<-SQL
+    begin
+      :geom := SDO_GEOMETRY(:sdo_gtype, :sdo_srid, :sdo_point, :sdo_elem_info_array, :sdo_ordinate_array);
+    end;
+  SQL
+  local_cursor.bind_param(:sdo_gtype, gtype, OraNumber)
+  local_cursor.bind_param(:sdo_srid, srid, OraNumber)
+  local_cursor.bind_param(:sdo_point, sdo_point, OCI8::Object::Mdsys::SdoPointType)
+  local_cursor.bind_param(:sdo_elem_info_array, sdo_elem_info_array, OCI8::Object::Mdsys::SdoElemInfoArray)
+  local_cursor.bind_param(:sdo_ordinate_array, sdo_ordinate_array, OCI8::Object::Mdsys::SdoOrdinateArray)
+  local_cursor.bind_param(:geom, OCI8::Object::Mdsys::SdoGeometry)
+  local_cursor.exec
+  local_cursor[:geom]
+end
+
+# these need to be defined before newing up will work:
+# based on information from https://github.com/kubo/ruby-oci8/issues/37#issuecomment-19814547
+module OCI8::Object::Mdsys
+  class SdoPointType < OCI8::Object::Base
+  end
+  class SdoElemInfoArray < OCI8::Object::Base
+  end
+  class SdoOrdinateArray < OCI8::Object::Base
+  end
+  class SdoGeometry < OCI8::Object::Base
+    set_typename('MDSYS.SDO_GEOMETRY')
+  end
+end


### PR DESCRIPTION
I was struggling with the behaviour of the ruby_value_to_ora_value function.

I tried reading from an Oracle table which included a (spatial) sdo_geometry column, and writing the same data back to an Oracle database using `plsql.table_name.insert(old_row)`. This did not work due to the complicated nature of the sdo_geometry and how it interacted with the ruby_value_to_ora_value function. 

I managed to create the SdoGeometry, but the ruby_value_to_ora_value function was trying to operate on it, trying to help out where it was not necessary, converting what was already an SdoGeometry to an SdoGeometry.

Whilst I aim for a more concise fix, the code committed resolves the issue of the function working where it does not need to.

Let me know if you need anything more (this is my first github pull!)
