### PR TITLE
use current_schema in PLSQL::Schema#schema_name

### DIFF
--- a/lib/plsql/schema.rb
+++ b/lib/plsql/schema.rb
@@ -90,7 +90,7 @@ module PLSQL
     # Current Oracle schema name
     def schema_name
       return nil unless connection
-      @schema_name ||= select_first("SELECT SYS_CONTEXT('userenv','session_user') FROM dual")[0]
+      @schema_name ||= select_first("SELECT SYS_CONTEXT('userenv','current_schema') FROM dual")[0]
     end
 
     # Default timezone to which database values will be converted - :utc or :local

--- a/spec/plsql/package_spec.rb
+++ b/spec/plsql/package_spec.rb
@@ -20,7 +20,6 @@ describe "Package" do
         END test_procedure;
       END;
     SQL
-
   end
   
   after(:all) do
@@ -65,6 +64,44 @@ describe "Package" do
     [:Test_Variable, :test_variable, 'test_variable', 'TEST_VARIABLE'].each do |name_variant|
       expect(package[name_variant]).to be_a PLSQL::Variable
     end
+  end
+
+  context "with a user with execute privilege who is not the package owner" do
+    before(:all) do
+      plsql.execute("grant execute on TEST_PACKAGE to #{DATABASE_USERS_AND_PASSWORDS[1][0]}")
+      @original_connection = plsql.connection
+      @conn = get_connection(1)
+    end
+
+    before(:each) do
+      # resetting connection clears cached package objects and schema name
+      plsql.connection = @conn
+    end
+
+    after(:all) do
+      plsql.logoff
+      plsql.connection = @original_connection
+    end
+
+    it "should not find existing package" do
+      expect(PLSQL::Package.find(plsql, :test_package)).to be_nil
+    end
+
+    context "who sets current_schema to match the package owner" do
+      before(:all) do
+        plsql.execute "ALTER SESSION set current_schema=#{DATABASE_USERS_AND_PASSWORDS[0][0]}"
+      end
+
+      it "should find existing package" do
+        expect(PLSQL::Package.find(plsql, :test_package)).not_to be_nil
+      end
+
+      it "should report an existing procedure as existing" do
+        expect(plsql.test_package.procedure_defined?(:test_procedure)).to be_truthy
+      end
+
+    end
+
   end
 
   describe "variables" do

--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -37,6 +37,13 @@ describe "Schema connection" do
     expect(plsql.schema_name).to eq(DATABASE_USERS_AND_PASSWORDS[0][0].upcase)
   end
 
+  it 'should match altered current_schema in database session' do
+    plsql.connection = @conn
+    expected_current_schema = DATABASE_USERS_AND_PASSWORDS[1][0]
+    plsql.execute "ALTER SESSION set current_schema=#{expected_current_schema}"
+    expect(plsql.schema_name).to eq(expected_current_schema.upcase)
+  end
+
   it "should return new schema name after reconnection" do
     plsql.connection = @conn
     expect(plsql.schema_name).to eq(DATABASE_USERS_AND_PASSWORDS[0][0].upcase)


### PR DESCRIPTION
We're using oracle-enhanced with schema: parameter set, so current_schema is different than the current user, which causes PL/SQL not to find available packages. current_schema should (?) be the same as session_user unless explicitly set otherwise, in which case we should use that.

I'm happy to write a specific test for this, but it'll make setup more complex since we'll need to create another user, do some grants, etc. Thoughts? 