### PR TITLE
Support for spaces in package variable declarations

### DIFF
--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -47,7 +47,7 @@ module PLSQL
 
     def metadata(type_string)
       case type_string
-      when /^(VARCHAR|VARCHAR2|CHAR|NVARCHAR2|NCHAR)(?:\s+)?(\((?:\s+)?(\d+)[\s\w]*\))?$/
+      when /^(VARCHAR|VARCHAR2|CHAR|NVARCHAR2|NCHAR)\s*(\(\s*(\d+)[\s\w]*\))?$/
         {:data_type => $1, :data_length => $3.to_i, :in_out => 'IN/OUT'}
       when /^(CLOB|NCLOB|BLOB)$/,
           /^(NUMBER)(\(.*\))?$/, /^(NATURAL|NATURALN|POSITIVE|POSITIVEN|SIGNTYPE|SIMPLE_INTEGER|PLS_INTEGER|BINARY_INTEGER)$/,

--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -47,7 +47,7 @@ module PLSQL
 
     def metadata(type_string)
       case type_string
-      when /^(VARCHAR|VARCHAR2|CHAR|NVARCHAR2|NCHAR)(\((\d+)[\s\w]*\))?$/
+      when /^(VARCHAR|VARCHAR2|CHAR|NVARCHAR2|NCHAR)(?:\s+)?(\((?:\s+)?(\d+)[\s\w]*\))?$/
         {:data_type => $1, :data_length => $3.to_i, :in_out => 'IN/OUT'}
       when /^(CLOB|NCLOB|BLOB)$/,
           /^(NUMBER)(\(.*\))?$/, /^(NATURAL|NATURALN|POSITIVE|POSITIVEN|SIGNTYPE|SIMPLE_INTEGER|PLS_INTEGER|BINARY_INTEGER)$/,

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -103,9 +103,11 @@ describe "Package variables /" do
     end
 
     it 'can use package variables with spaces in size' do
-      expect(plsql.test_package.varchar_with_spaces1).to eq('a string')
-      expect(plsql.test_package.varchar_with_spaces2).to eq('a string')
-      expect(plsql.test_package.varchar_with_spaces3).to eq('a string')
+      aggregate_failures 'for different formats' do
+        expect(plsql.test_package.varchar_with_spaces1).to eq('a string')
+        expect(plsql.test_package.varchar_with_spaces2).to eq('a string')
+        expect(plsql.test_package.varchar_with_spaces3).to eq('a string')
+      end
     end
 
   end

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -20,6 +20,9 @@ describe "Package variables /" do
           char_variable char(10) ;
           nvarchar2_variable NVARCHAR2(50);
           nchar_variable NCHAR(10);
+          varchar_with_spaces1 VARCHAR2 (50) := 'a string';
+          varchar_with_spaces2 VARCHAR2( 50 ):= 'a string';
+          varchar_with_spaces3 VARCHAR2 (50  BYTE ) := 'a string';
         END;
       SQL
       plsql.execute <<-SQL
@@ -97,6 +100,12 @@ describe "Package variables /" do
     it "should set and get NCHAR variable" do
       plsql.test_package.nchar_variable = 'abc'
       expect(plsql.test_package.nchar_variable).to eq('abc' + ' '*7)
+    end
+
+    it 'can use package variables with spaces in size' do
+      expect(plsql.test_package.varchar_with_spaces1).to eq('a string')
+      expect(plsql.test_package.varchar_with_spaces2).to eq('a string')
+      expect(plsql.test_package.varchar_with_spaces3).to eq('a string')
     end
 
   end


### PR DESCRIPTION
Fixes rsim/ruby-plsql#111
