### PR TITLE
Support Rails 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,14 @@ gemfile:
     - gemfiles/Gemfile.activerecord-4.1
     - gemfiles/Gemfile.activerecord-4.2
     - gemfiles/Gemfile.activerecord-5.0
+
+matrix:
+    exclude:
+      - gemfile: Gemfile
+        rvm: 1.9.3
+      - gemfile: Gemfile
+        rvm: jruby-1.7.9
+      - gemfile: gemfiles/Gemfile.activerecord-5.0
+        rvm: 1.9.3
+      - gemfile: gemfiles/Gemfile.activerecord-5.0
+        rvm: jruby-1.7.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,4 @@ rvm:
 gemfile:
     - Gemfile
     - gemfiles/Gemfile.activerecord-4.1
+    - gemfiles/Gemfile.activerecord-4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,4 @@ gemfile:
     - Gemfile
     - gemfiles/Gemfile.activerecord-4.1
     - gemfiles/Gemfile.activerecord-4.2
+    - gemfiles/Gemfile.activerecord-5.0

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :test, :development do
   gem 'rspec', '~> 3.1'
 
   unless ENV['NO_ACTIVERECORD']
-    gem 'activerecord', '>= 3.2.3', '< 4.3.0'
-    gem 'activerecord-oracle_enhanced-adapter', '>= 1.4.1', '< 1.7.0'
+    gem 'activerecord', '>= 3.2.3', '< 5.1.0'
+    gem 'activerecord-oracle_enhanced-adapter', '>= 1.4.1', '< 1.8.0'
     gem 'simplecov', '>= 0'
   end
 

--- a/gemfiles/Gemfile.activerecord-4.2
+++ b/gemfiles/Gemfile.activerecord-4.2
@@ -1,0 +1,21 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'juwelier', '~> 2.0'
+  gem 'rspec_junit_formatter'
+end
+
+group :test, :development do
+  gem 'rake', '>= 10.0'
+  gem 'rspec', '~> 3.1'
+
+  unless ENV['NO_ACTIVERECORD']
+    gem 'activerecord', '~> 4.2.0'
+    gem 'activerecord-oracle_enhanced-adapter', '~> 1.6.0'
+    gem 'simplecov', '>= 0'
+  end
+
+  platforms :ruby, :mswin, :mingw do
+    gem 'ruby-oci8', '~> 2.1'
+  end
+end

--- a/gemfiles/Gemfile.activerecord-5.0
+++ b/gemfiles/Gemfile.activerecord-5.0
@@ -1,0 +1,21 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'juwelier', '~> 2.0'
+  gem 'rspec_junit_formatter'
+end
+
+group :test, :development do
+  gem 'rake', '>= 10.0'
+  gem 'rspec', '~> 3.1'
+
+  unless ENV['NO_ACTIVERECORD']
+    gem 'activerecord', '~> 5.0.0'
+    gem 'activerecord-oracle_enhanced-adapter', '~> 1.7.0'
+    gem 'simplecov', '>= 0'
+  end
+
+  platforms :ruby, :mswin, :mingw do
+    gem 'ruby-oci8', '~> 2.1'
+  end
+end


### PR DESCRIPTION
This pull request supports Rails 5.0 and Oracle enhanced adapter 1.7 supporting Rails 5.

I have run `rake spec` locally then most of specs are fine except for #114 which also reproduces with Rails 4.2.