### PR TITLE
Add build matrix support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,7 @@ rvm:
   - 1.9.3
   - jruby-1.7.9
   - jruby-9.0.5.0
+
+gemfile:
+    - Gemfile
+    - gemfiles/Gemfile.activerecord-4.1

--- a/gemfiles/Gemfile.activerecord-4.1
+++ b/gemfiles/Gemfile.activerecord-4.1
@@ -1,0 +1,21 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'juwelier', '~> 2.0'
+  gem 'rspec_junit_formatter'
+end
+
+group :test, :development do
+  gem 'rake', '>= 10.0'
+  gem 'rspec', '~> 3.1'
+
+  unless ENV['NO_ACTIVERECORD']
+    gem 'activerecord', '~> 4.1.0'
+    gem 'activerecord-oracle_enhanced-adapter', '~> 1.5.0'
+    gem 'simplecov', '>= 0'
+  end
+
+  platforms :ruby, :mswin, :mingw do
+    gem 'ruby-oci8', '~> 2.1'
+  end
+end


### PR DESCRIPTION
Travis CI build matrix enables more flexibility in configuring which combinations of versions of ruby and ActiveRecord to test. In particular, it would help to skip incompatible scenarios like Rails 5.0 with ruby 1.9