### PR TITLE
Bump ruby versions for Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ rvm:
   - 1.9.3
   - jruby-1.7.26
   - jruby-9.0.5.0
+  - jruby-9.1.6.0
 
 gemfile:
     - Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ install:
 
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.4
+  - 2.3.3
+  - 2.2.6
   - 1.9.3
-  - jruby-1.7.9
+  - jruby-1.7.26
   - jruby-9.0.5.0
 
 gemfile:
@@ -45,8 +45,8 @@ matrix:
       - gemfile: Gemfile
         rvm: 1.9.3
       - gemfile: Gemfile
-        rvm: jruby-1.7.9
+        rvm: jruby-1.7.26
       - gemfile: gemfiles/Gemfile.activerecord-5.0
         rvm: 1.9.3
       - gemfile: gemfiles/Gemfile.activerecord-5.0
-        rvm: jruby-1.7.9
+        rvm: jruby-1.7.26


### PR DESCRIPTION
This pull request bumps the existing Ruby versions to the latest point release and adds JRuby 9.1.6 which is compatible with Ruby 2.3.1

```
$ ruby -v
jruby 9.1.6.0 (2.3.1) 2016-11-09 0150a76 OpenJDK 64-Bit Server VM 25.111-b16 on 1.8.0_111-b16 +jit [linux-x86_64]
```