### PR TITLE
Allow ojdbc7.jar when Java version is 1.7 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,16 @@ In addition install either ruby-oci8 (for MRI/YARV) or copy Oracle JDBC driver t
 If you are using MRI 1.8, 1.9 or 2.x Ruby implementation then you need to install ruby-oci8 gem (version 2.0.x or 2.1.x)
 as well as Oracle client, e.g. [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html).
 
-If you are using JRuby then you need to download latest [Oracle JDBC driver](http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html) - either ojdbc6.jar for Java 6, 7, 8 or ojdbc5.jar for Java 5. And copy this file to one of these locations:
+If you are using JRuby then you need to download latest [Oracle JDBC driver](http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-112010-090769.html) - either ojdbc7.jar for Java 8 and 7, ojdbc6.jar for Java 6, 7, 8 or ojdbc5.jar for Java 5. You can refer [the support matrix](http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-faq-090281.html#01_03) for details.
 
-* in `./lib` directory of Rails application and require it manually
-* in some directory which is in `PATH`
+And copy this file to one of these locations. JDBC driver will be searched in this order:
+
 * in `JRUBY_HOME/lib` directory
+* in `./lib` directory of Rails application
 * or include path to JDBC driver jar file in Java `CLASSPATH`
+* in some directory which is in `PATH`
+
+If you put multiple versions of JDBC driver in the same directory the higher version one will be used.
 
 Make sure to setup the following Oracle-specific environment variables properly
 

--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -5,21 +5,31 @@ begin
   # ojdbc6.jar or ojdbc5.jar file should be in JRUBY_HOME/lib or should be in ENV['PATH'] or load path
 
   java_version = java.lang.System.getProperty("java.version")
-  ojdbc_jar = if java_version =~ /^1.5/
-    "ojdbc5.jar"
-  elsif java_version >= '1.6'
-    "ojdbc6.jar"
+  ojdbc_jars = if java_version =~ /^1.5/
+    %w(ojdbc5.jar)
+  elsif java_version =~ /^1.6/
+    %w(ojdbc6.jar)
+  elsif java_version >= "1.7"
+    # Oracle 11g client ojdbc6.jar is also compatible with Java 1.7
+    # Oracle 12c client provides new ojdbc7.jar
+    %w(ojdbc7.jar ojdbc6.jar)
   else
-    nil
+    []
   end
 
-  unless ENV_JAVA['java.class.path'] =~ Regexp.new(ojdbc_jar)
+  if ENV_JAVA["java.class.path"] !~ Regexp.new(ojdbc_jars.join("|"))
     # On Unix environment variable should be PATH, on Windows it is sometimes Path
-    env_path = (ENV["PATH"] || ENV["Path"] || '').split(/[:;]/)
+    env_path = (ENV["PATH"] || ENV["Path"] || "").split(File::PATH_SEPARATOR)
     # Look for JDBC driver at first in lib subdirectory (application specific JDBC file version)
     # then in Ruby load path and finally in environment PATH
-    if ojdbc_jar_path = ['./lib'].concat($LOAD_PATH).concat(env_path).find{|d| File.exists?(File.join(d,ojdbc_jar))}
-      require File.join(ojdbc_jar_path,ojdbc_jar)
+    ["./lib"].concat($LOAD_PATH).concat(env_path).detect do |dir|
+      # check any compatible JDBC driver in the priority order
+      ojdbc_jars.any? do |ojdbc_jar|
+        if File.exists?(file_path = File.join(dir, ojdbc_jar))
+          require file_path
+          true
+        end
+      end
     end
   end
 
@@ -32,7 +42,7 @@ begin
 
 rescue LoadError, NameError
   # JDBC driver is unavailable.
-  raise LoadError, "ERROR: ruby-plsql could not load Oracle JDBC driver. Please install #{ojdbc_jar || "Oracle JDBC"} library."
+  raise LoadError, "ERROR: ruby-plsql could not load Oracle JDBC driver. Please install #{ojdbc_jars.empty? ? "Oracle JDBC" : ojdbc_jars.join(' or ') } library."
 end
 
 module PLSQL


### PR DESCRIPTION
This pull request allows to use ojdbc7.jar when Java version is 1.7 or higher.

Refer http://www.oracle.com/technetwork/database/enterprise-edition/jdbc-faq-090281.html#01_02 for JDBC driver and JDK version matrix.