### PR TITLE
Suppress `warning: instance variable @dbms_output_stream not initialized`

### DIFF
--- a/lib/plsql/schema.rb
+++ b/lib/plsql/schema.rb
@@ -20,6 +20,7 @@ module PLSQL
       self.connection = raw_conn
       @schema_name = schema ? schema.to_s.upcase : nil
       @original_schema = original_schema
+      @dbms_output_stream = nil
     end
 
     # Returns connection wrapper object (this is not raw OCI8 or JDBC connection!)


### PR DESCRIPTION
I found the following warning in `rake spec` of [oracle-enhanced](https://github.com/rsim/oracle-enhanced).

```sh
% ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
% bundle exec rake spec
(snip)
/home/vagrant/src/ruby-plsql/lib/plsql/schema.rb:161: warning: instance variable @dbms_output_stream not initialized
```

This PR will suppress this.

I confirmed that these tests passed with local Oracle 11g environment at ruby-plsql, oracle-enhanced ([master](https://github.com/rsim/oracle-enhanced/tree/44381d397f77672939c19b4dfa5136b28429f0c3)).