### PR TITLE
Remove development dependencies for CI Tests for active record 4.1 and 4.2 due to ruby 1.9.3

### DIFF
--- a/gemfiles/Gemfile.activerecord-4.1
+++ b/gemfiles/Gemfile.activerecord-4.1
@@ -1,10 +1,5 @@
 source 'http://rubygems.org'
 
-group :development do
-  gem 'juwelier', '~> 2.0'
-  gem 'rspec_junit_formatter'
-end
-
 group :test, :development do
   gem 'rake', '>= 10.0'
   gem 'rspec', '~> 3.1'

--- a/gemfiles/Gemfile.activerecord-4.2
+++ b/gemfiles/Gemfile.activerecord-4.2
@@ -1,10 +1,5 @@
 source 'http://rubygems.org'
 
-group :development do
-  gem 'juwelier', '~> 2.0'
-  gem 'rspec_junit_formatter'
-end
-
 group :test, :development do
   gem 'rake', '>= 10.0'
   gem 'rspec', '~> 3.1'


### PR DESCRIPTION
Some of the development dependencies for activerecord 4.x are not compatible with ruby 1.9.x - hence removing them