### PR TITLE
Test Rails 5.1.0.beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ gemfile:
     - gemfiles/Gemfile.activerecord-4.1
     - gemfiles/Gemfile.activerecord-4.2
     - gemfiles/Gemfile.activerecord-5.0
+    - gemfiles/Gemfile.activerecord-5.1
 
 matrix:
     exclude:
@@ -53,3 +54,9 @@ matrix:
         rvm: 1.9.3
       - gemfile: gemfiles/Gemfile.activerecord-5.0
         rvm: jruby-1.7.26
+      - gemfile: gemfiles/Gemfile.activerecord-5.1
+        rvm: 1.9.3
+      - gemfile: gemfiles/Gemfile.activerecord-5.1
+        rvm: jruby-1.7.26
+      - gemfile: gemfiles/Gemfile.activerecord-5.1
+        rvm: jruby-9.0.5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ rvm:
   - 1.9.3
   - jruby-1.7.26
   - jruby-9.0.5.0
-  - jruby-9.1.6.0
+  - jruby-9.1.7.0
 
 gemfile:
     - Gemfile

--- a/gemfiles/Gemfile.activerecord-5.1
+++ b/gemfiles/Gemfile.activerecord-5.1
@@ -1,0 +1,21 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'juwelier', '~> 2.0'
+  gem 'rspec_junit_formatter'
+end
+
+group :test, :development do
+  gem 'rake', '>= 10.0'
+  gem 'rspec', '~> 3.1'
+
+  unless ENV['NO_ACTIVERECORD']
+    gem 'activerecord', '~> 5.1.0.beta'
+    gem 'activerecord-oracle_enhanced-adapter', '~> 1.8.0.beta'
+    gem 'simplecov', '>= 0'
+  end
+
+  platforms :ruby, :mswin, :mingw do
+    gem 'ruby-oci8', '~> 2.1'
+  end
+end


### PR DESCRIPTION
This pull request adds testing Rails 5.1.0.beta. 

JRuby 9.0.x has been excluded since Oracle enhanced adapter 1.8 will support JRuby 9.1.7.0 or higher.
Refer rsim/oracle-enhanced/pull/1147
