### PR TITLE
Test Rails 5.1.0.rc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ install:
 
 language: ruby
 rvm:
-  - 2.4.0
+  - 2.4.1
   - 2.3.3
   - 2.2.6
   - 1.9.3
   - jruby-1.7.26
   - jruby-9.0.5.0
-  - jruby-9.1.7.0
+  - jruby-9.1.8.0
 
 gemfile:
     - Gemfile

--- a/gemfiles/Gemfile.activerecord-5.1
+++ b/gemfiles/Gemfile.activerecord-5.1
@@ -10,8 +10,8 @@ group :test, :development do
   gem 'rspec', '~> 3.1'
 
   unless ENV['NO_ACTIVERECORD']
-    gem 'activerecord', '~> 5.1.0.beta'
-    gem 'activerecord-oracle_enhanced-adapter', '~> 1.8.0.beta'
+    gem 'activerecord', '~> 5.1.0.rc'
+    gem 'activerecord-oracle_enhanced-adapter', '~> 1.8.0.rc'
     gem 'simplecov', '>= 0'
   end
 


### PR DESCRIPTION
Rails 5.1.0.rc1 has been released. Also it bumps CRuby and JRuby version to the latest ones.