### PR TITLE
Suppress a Ruby warnings

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -216,7 +216,7 @@ module PLSQL
             raise ArgumentError, "You should pass Array value for collection type parameter" unless value.is_a?(Array)
             elem_list = value.map do |elem|
               if (attr_tdo = tdo.coll_attr.typeinfo)
-                attr_type, attr_length = plsql_to_ruby_data_type(:data_type => 'OBJECT', :sql_type_name => attr_tdo.typename)
+                attr_type, _ = plsql_to_ruby_data_type(:data_type => 'OBJECT', :sql_type_name => attr_tdo.typename)
               else
                 attr_type = elem.class
               end
@@ -235,7 +235,7 @@ module PLSQL
               case attr.datatype
               when OCI8::TDO::ATTR_NAMED_TYPE, OCI8::TDO::ATTR_NAMED_COLLECTION
                 # nested object type or collection
-                attr_type, attr_length = plsql_to_ruby_data_type(:data_type => 'OBJECT', :sql_type_name => attr.typeinfo.typename)
+                attr_type, _ = plsql_to_ruby_data_type(:data_type => 'OBJECT', :sql_type_name => attr.typeinfo.typename)
                 object_attrs[key] = ruby_value_to_ora_value(object_attrs[key], attr_type)
               end
             end

--- a/lib/plsql/table.rb
+++ b/lib/plsql/table.rb
@@ -58,7 +58,7 @@ module PLSQL
       ) do |r|
         column_name, position,
               data_type, data_length, data_precision, data_scale, char_used,
-              data_type_owner, data_type_mod, typecode, nullable, data_default = r
+              data_type_owner, _, typecode, nullable, data_default = r
         # remove scale (n) from data_type (returned for TIMESTAMPs and INTERVALs)
         data_type.sub!(/\(\d+\)/,'')
         # store column metadata

--- a/lib/plsql/type.rb
+++ b/lib/plsql/type.rb
@@ -67,7 +67,7 @@ module PLSQL
       ) do |r|
         attr_name, position,
               data_type, data_length, data_precision, data_scale,
-              data_type_owner, data_type_mod, typecode = r
+              data_type_owner, _, typecode = r
         @attributes[attr_name.downcase.to_sym] = {
           :position => position && position.to_i,
           :data_type => data_type_owner && (typecode == 'COLLECTION' ? 'TABLE' : 'OBJECT' ) || data_type,

--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -84,10 +84,10 @@ module PLSQL
           :in_out => 'IN/OUT',
           :fields => {}
         }
-        table.columns.each do |name, column|
+        table.columns.each do |name, col|
           record_metadata[:fields][name] =
-            {:data_type => column[:data_type], :data_length => column[:data_length], :sql_type_name => column[:sql_type_name], 
-            :position => column[:position], :in_out => 'IN/OUT'}
+            {:data_type => col[:data_type], :data_length => col[:data_length], :sql_type_name => col[:sql_type_name],
+            :position => col[:position], :in_out => 'IN/OUT'}
         end
         record_metadata
       else


### PR DESCRIPTION
I found the following warnings in `rake spec` of [oracle-enhanced](https://github.com/rsim/oracle-enhanced).

```sh
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
% bundle exec rake
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
==> Effective ActiveRecord version 5.2.0.alpha
/home/vagrant/.rvm/rubies/ruby-2.4.1/bin/ruby -I/home/vagrant/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.5.4/lib:/home/vagrant/.rvm/gems/ruby-2.4.1/gems/rspec-support-3.5.0/lib /home/vagrant/.rvm/gems/ruby-2.4.1/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
==> Loading config from ENV or use default
==> Running specs with MRI version 2.4.1
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-oci8-0ffd0c8787bd/lib/oci8/oci8.rb:627: warning: method redefined; discarding old initialize
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-plsql-f3a4ba8034bb/lib/plsql/variable.rb:87: warning: shadowing outer local variable - column
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-plsql-f3a4ba8034bb/lib/plsql/table.rb:61: warning: assigned but unused variable - data_type_mod
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-plsql-f3a4ba8034bb/lib/plsql/type.rb:70: warning: assigned but unused variable - data_type_mod
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-plsql-f3a4ba8034bb/lib/plsql/oci_connection.rb:219: warning: assigned but unused variable - attr_length
/home/vagrant/.rvm/gems/ruby-2.4.1/bundler/gems/ruby-plsql-f3a4ba8034bb/lib/plsql/oci_connection.rb:238: warning: assigned but unused variable - attr_length
==> Effective ActiveRecord version 5.2.0.alpha
(snip)
```

This PR suppresses the following 2 warnings.

- `warning: assigned but unused variable`
- `warning: shadowing outer local variable - column`

I will explain a bit about this change.

First is about `warning: assigned but unused variable`. 

https://github.com/koic/ruby-plsql/commit/a6e89f3679275ee8b20dfea46b3b5c11f63e75d9

I often see the name `_` to represent unused variable. In this PR, it added `_` to prefix to keep intention of variable name.

The following is a small sample of reproduction.

```ruby
% ruby -w -e 'def foo; intentional_name = "an unused value"; end'
-e:1: warning: assigned but unused variable - intentional_name
% ruby -w -e 'def foo; _intentional_name = "an unused value"; end'
# => There is no warning
```

Next, it is about `warning: shadowing outer local variable - column`.

https://github.com/koic/ruby-plsql/commit/1f67ee36d4e66face2059ae77b4f2582ee5e3233

I added `_` to the prefix because I could not think of a variable name with a clear intention beyond the name` column`.

Both add `_` to the prefix, but intention differs slightly like this.

Thank you.
