### PR TITLE
Use final version of 5.1 and oracle-enhanced 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :test, :development do
   gem 'rspec', '~> 3.1'
 
   unless ENV['NO_ACTIVERECORD']
-    gem 'activerecord', '>= 3.2.3', '< 5.1.0'
-    gem 'activerecord-oracle_enhanced-adapter', '>= 1.4.1', '< 1.8.0'
+    gem 'activerecord', '>= 3.2.3', '< 5.2.0'
+    gem 'activerecord-oracle_enhanced-adapter', '>= 1.4.1', '< 1.9.0'
     gem 'simplecov', '>= 0'
   end
 

--- a/gemfiles/Gemfile.activerecord-5.1
+++ b/gemfiles/Gemfile.activerecord-5.1
@@ -10,8 +10,8 @@ group :test, :development do
   gem 'rspec', '~> 3.1'
 
   unless ENV['NO_ACTIVERECORD']
-    gem 'activerecord', '~> 5.1.0.rc'
-    gem 'activerecord-oracle_enhanced-adapter', '~> 1.8.0.rc'
+    gem 'activerecord', '~> 5.1.0'
+    gem 'activerecord-oracle_enhanced-adapter', '~> 1.8.0'
     gem 'simplecov', '>= 0'
   end
 


### PR DESCRIPTION
Rails 5.1 and oracle enhanced adapter 1.8.0 have been released so we can now declare dependency on their final versions.