### PR TITLE
Allow calling procedures in INVALID status

### DIFF
--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -2114,7 +2114,7 @@ describe "Synonyms /" do
     it "should raise error when function from invalid package body is called" do
       expect {
         plsql.test_invalid_package.test_invalid_function('test')
-      }.to raise_error(OCIError, /ORA-04063/)
+      }.to raise_error(oracle_error_class, /ORA-04063/)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,14 @@ if ENV['USE_VM_DATABASE'] == 'Y'
   end
 end
 
+def oracle_error_class
+  unless defined?(JRUBY_VERSION)
+    OCIError
+  else
+    java.sql.SQLException
+  end
+end
+
 def get_eazy_connect_url(svc_separator = "")
   "#{DATABASE_HOST}:#{DATABASE_PORT}#{svc_separator}#{DATABASE_SERVICE_NAME}"
 end


### PR DESCRIPTION
This builds off of @JDominator's work in #90.

With this change, ruby-plsql will still attempt to call procedures and functions even if Oracle has them in an "INVALID" status.

The "INVALID" status does not necessarily mean that the procedure has errors and cannot be called; it can also mean that an object on which it depends has been changed and the procedure needs to be recompiled.  This can happen quite frequently and would normally be a non-event except that ruby-plsql currently will not even attempt to call an invalid procedure (or a procedure in an invalid package body) and pre-emptively raises an exception.

Upon calling the invalid procedure, Oracle will implicitly attempt to recompile it.  If the recompilation fails, then a specific error will be raised.  Thus it is better to try to call the procedure: if the call succeeds, then great, otherwise we get a more specific error.

There is one case where the invalid procedure cannot be called even if that call would ultimately be successful:

If a top-level procedure or function has been compiled with errors, then there will be no row for it in the ALL_PROCEDURES view.  ruby-plsql depends on the row in this view to determine the procedure's object_id in Oracle versions 11g and above.  In this case, we must still raise an error.  This will not happen on transient problems where a dependency changes and the procedure can be implicitly recompiled.  However, if the procedure ever fails compilation, then it will have to be manually recompiled before ruby-plsql can call it.

resolves #90 