### PR TITLE
Add license to gemspec

### DIFF
--- a/ruby-plsql.gemspec
+++ b/ruby-plsql.gemspec
@@ -71,6 +71,7 @@ Gem::Specification.new do |s|
     "spec/support/unlock_and_setup_hr_user.sql"
   ]
   s.homepage = "http://github.com/rsim/ruby-plsql".freeze
+  s.license = "MIT".freeze
   s.rubygems_version = "2.6.4".freeze
   s.summary = "Ruby API for calling Oracle PL/SQL procedures.".freeze
 


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/ruby-plsql)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.