### PR TITLE
Generate a license for gemspec with `rake gemspec`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ begin
   EOS
     gem.email = "raimonds.simanovskis@gmail.com"
     gem.homepage = "http://github.com/rsim/ruby-plsql"
+    gem.license = "MIT".freeze
     gem.authors = ["Raimonds Simanovskis"]
     gem.extra_rdoc_files = ['README.md']
   end

--- a/ruby-plsql.gemspec
+++ b/ruby-plsql.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |s|
     "spec/support/unlock_and_setup_hr_user.sql"
   ]
   s.homepage = "http://github.com/rsim/ruby-plsql".freeze
-  s.license = "MIT".freeze
+  s.licenses = ["MIT".freeze]
   s.rubygems_version = "2.6.4".freeze
   s.summary = "Ruby API for calling Oracle PL/SQL procedures.".freeze
 
@@ -108,4 +108,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<ruby-oci8>.freeze, ["~> 2.1"])
   end
 end
-


### PR DESCRIPTION
Follow up for #130.

The above PR did not generate ruby-plsql.gemspec with `rake gemspec`. This PR has been improved based on `rake gemspec`.
