### PR TITLE
Bump ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ install:
 
 language: ruby
 rvm:
-  - 2.4.1
-  - 2.3.3
-  - 2.2.6
+  - 2.4.3
+  - 2.3.6
+  - 2.2.9
   - 1.9.3
-  - jruby-1.7.26
+  - jruby-1.7.27
   - jruby-9.0.5.0
-  - jruby-9.1.8.0
+  - jruby-9.1.15.0
 
 gemfile:
     - Gemfile
@@ -49,14 +49,14 @@ matrix:
       - gemfile: Gemfile
         rvm: 1.9.3
       - gemfile: Gemfile
-        rvm: jruby-1.7.26
+        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.0
         rvm: 1.9.3
       - gemfile: gemfiles/Gemfile.activerecord-5.0
-        rvm: jruby-1.7.26
+        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.1
         rvm: 1.9.3
       - gemfile: gemfiles/Gemfile.activerecord-5.1
-        rvm: jruby-1.7.26
+        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.1
         rvm: jruby-9.0.5.0


### PR DESCRIPTION
* Ruby 2.4.3 Released
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released/

* Ruby 2.3.6 Released
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released/

* Ruby 2.2.9 Released
https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/

* JRuby 1.7.27 Released
http://jruby.org/2017/05/11/jruby-1-7-27

* JRuby 9.1.15.0 Released
http://jruby.org/2017/12/07/jruby-9-1-15-0