### PR TITLE
Introduce probot-stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,37 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale Issue or Pull Request is closed
+daysUntilClose: 7
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - "[Status] Maybe Later"
+# Label to use when marking as stale
+staleLabel: wontfix
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: false
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+# Limit to only `issues` or `pulls`
+# only: issues
+#
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
Introduce probot-stale to manage inactive issues or pull requests

https://github.com/probot/stale

@rsim Would you configure robot-stale if you agree.

* Steps to enable probot-stale
https://github.com/integration/probot-stale

Click "Install" -> "Repository access" -> "Only select repositories" and choose "oracle-enhanced"