### PR TITLE
Drop JRuby 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ rvm:
   - 2.3.6
   - 2.2.9
   - 1.9.3
-  - jruby-1.7.27
   - jruby-9.0.5.0
   - jruby-9.1.15.0
   - ruby-head
@@ -52,22 +51,14 @@ matrix:
     exclude:
       - gemfile: Gemfile
         rvm: 1.9.3
-      - gemfile: Gemfile
-        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.0
         rvm: 1.9.3
-      - gemfile: gemfiles/Gemfile.activerecord-5.0
-        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.1
         rvm: 1.9.3
-      - gemfile: gemfiles/Gemfile.activerecord-5.1
-        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.1
         rvm: jruby-9.0.5.0
       - gemfile: gemfiles/Gemfile.activerecord-5.2
         rvm: 1.9.3
-      - gemfile: gemfiles/Gemfile.activerecord-5.2
-        rvm: jruby-1.7.27
       - gemfile: gemfiles/Gemfile.activerecord-5.2
         rvm: jruby-9.0.5.0
     allow_failures:


### PR DESCRIPTION
This pull request drops JRuby 1.7 support from ruby-plsql proposed in #145