### PR TITLE
Drop JRuby 9.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ rvm:
   - 2.4.3
   - 2.3.6
   - 2.2.9
-  - jruby-9.0.5.0
   - jruby-9.1.15.0
   - ruby-head
   - jruby-head
@@ -45,11 +44,6 @@ gemfile:
     - gemfiles/Gemfile.activerecord-5.2
 
 matrix:
-    exclude:
-      - gemfile: gemfiles/Gemfile.activerecord-5.1
-        rvm: jruby-9.0.5.0
-      - gemfile: gemfiles/Gemfile.activerecord-5.2
-        rvm: jruby-9.0.5.0
     allow_failures:
       - rvm: ruby-head
       - rvm: jruby-head


### PR DESCRIPTION
This pull request drops JRuby 9.0 support from ruby-plsql proposed in #145