### PR TITLE
Drop CRuby 2.1 or lower support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ rvm:
   - 2.4.3
   - 2.3.6
   - 2.2.9
-  - 1.9.3
   - jruby-9.0.5.0
   - jruby-9.1.15.0
   - ruby-head
@@ -47,16 +46,8 @@ gemfile:
 
 matrix:
     exclude:
-      - gemfile: Gemfile
-        rvm: 1.9.3
-      - gemfile: gemfiles/Gemfile.activerecord-5.0
-        rvm: 1.9.3
-      - gemfile: gemfiles/Gemfile.activerecord-5.1
-        rvm: 1.9.3
       - gemfile: gemfiles/Gemfile.activerecord-5.1
         rvm: jruby-9.0.5.0
-      - gemfile: gemfiles/Gemfile.activerecord-5.2
-        rvm: 1.9.3
       - gemfile: gemfiles/Gemfile.activerecord-5.2
         rvm: jruby-9.0.5.0
     allow_failures:


### PR DESCRIPTION
This pull request drops Ruby 2.1 or lower support from ruby-plsql proposed in #145