### PR TITLE
Avoid using `OCI8#describe_synonym` to use the same code

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -277,15 +277,7 @@ module PLSQL
     end
 
     def describe_synonym(schema_name, synonym_name)
-      if schema_name == "PUBLIC"
-        full_name = synonym_name.to_s
-      else
-        full_name = "#{schema_name}.#{synonym_name}"
-      end
-      metadata = raw_connection.describe_synonym(full_name)
-      [metadata.schema_name, metadata.name]
-    rescue OCIError
-      nil
+      super
     end
 
     def database_version


### PR DESCRIPTION
between CRuby with ruby-oci8 and JRuby

`OCI8#describe_synonym` was implemented
to address some performance problem with `all_synonyms`
but now I do not see any performance regression due to this change.

In the very long term, when `ruby-odpi` is production ready and
ruby-plsql uses `ruby-odpi` instead of `ruby-oci8`,
it will not support `OCI8#describe_synonym`.
Refer https://github.com/kubo/ruby-odpi/issues/1#issuecomment-324360714

Even using ruby-oci8 it will use the same `PLSQL::Connection#describe_table`
for both CRuby and JRuby connections, which reduces some of code.