### PR TITLE
Remove `OCI8#describe_synonym` 

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -276,10 +276,6 @@ module PLSQL
       end
     end
 
-    def describe_synonym(schema_name, synonym_name)
-      super
-    end
-
     def database_version
       @database_version ||= (version = raw_connection.oracle_server_version) &&
         [version.major, version.minor, version.update, version.patch]


### PR DESCRIPTION
To follow up #153