### PR TITLE
Suppress warning `BigDecimal.new` is deprecated

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -295,7 +295,7 @@ module PLSQL
 
       def ora_number_to_ruby_number(num)
         # return BigDecimal instead of Float to avoid rounding errors
-        num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal.new(num.to_s))
+        num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal(num.to_s))
       end
 
       def ora_date_to_ruby_date(val)


### PR DESCRIPTION
This PR suppresses the following warning.

```console
% ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
% RUBYOPT=-w bundle exec rake
(snip)
/home/vagrant/src/ruby-plsql/lib/plsql/oci_connection.rb:298: warning:
BigDecimal.new is deprecated; use Kernel.BigDecimal method instead.
```