### PR TITLE
Bump Ruby versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ install:
 
 language: ruby
 rvm:
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
-  - jruby-9.1.15.0
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
+  - jruby-9.2.0.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
"Ruby 2.5.1 Released"
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/

"Ruby 2.4.4 Released"
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/

"Ruby 2.3.7 Released"
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/

"Ruby 2.2.10 Released"
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/

"JRuby 9.2.0.0 Released"
http://jruby.org/2018/05/24/jruby-9-2-0-0.html