### PR TITLE
Bump RuboCop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
 engines:
   rubocop:
     enabled: true
-    channel: rubocop-0-51
+    channel: rubocop-0-58
 
 ratings:
   paths:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -135,7 +135,7 @@ Style/UnneededPercentQ:
 
 # Align `end` with the matching keyword or starting expression except for
 # assignments, where it should be aligned with the LHS.
-Lint/EndAlignment:
+Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
   AutoCorrect: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 # We should not use cops only available for Ruby 2.1 or later
 # since ruby-plsql itself supports Ruby 1.9.3
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   DisabledByDefault: true
 
 # Prefer &&/|| over and/or.

--- a/lib/plsql/procedure_call.rb
+++ b/lib/plsql/procedure_call.rb
@@ -318,17 +318,17 @@ module PLSQL
 
       def add_record_declaration(argument, argument_metadata)
         @declare_sql << if argument_metadata[:type_subname]
-                          "l_#{argument} #{argument_metadata[:sql_type_name]};\n"
-                        else
-                          fields_metadata = argument_metadata[:fields]
-                          sql = "TYPE t_#{argument} IS RECORD (\n"
-                          sql << record_fields_sorted_by_position(fields_metadata).map do |field|
-                            metadata = fields_metadata[field]
-                            "#{field} #{type_to_sql(metadata)}"
-                          end.join(",\n")
-                          sql << ");\n"
-                          sql << "l_#{argument} t_#{argument};\n"
-                        end
+          "l_#{argument} #{argument_metadata[:sql_type_name]};\n"
+        else
+          fields_metadata = argument_metadata[:fields]
+          sql = "TYPE t_#{argument} IS RECORD (\n"
+          sql << record_fields_sorted_by_position(fields_metadata).map do |field|
+            metadata = fields_metadata[field]
+            "#{field} #{type_to_sql(metadata)}"
+          end.join(",\n")
+          sql << ");\n"
+          sql << "l_#{argument} t_#{argument};\n"
+        end
       end
 
       def record_fields_sorted_by_position(fields_metadata)
@@ -429,10 +429,10 @@ module PLSQL
         @return_vars << argument
         @return_vars_metadata[argument] = argument_metadata.merge(data_type: "REF CURSOR")
         @return_sql << if is_index_by_table
-                         "i__ := l_#{argument}.FIRST;\nLOOP\nEXIT WHEN i__ IS NULL;\n"
-                       else
-                         "IF l_#{argument}.COUNT > 0 THEN\nFOR i__ IN l_#{argument}.FIRST..l_#{argument}.LAST LOOP\n"
-                       end
+          "i__ := l_#{argument}.FIRST;\nLOOP\nEXIT WHEN i__ IS NULL;\n"
+        else
+          "IF l_#{argument}.COUNT > 0 THEN\nFOR i__ IN l_#{argument}.FIRST..l_#{argument}.LAST LOOP\n"
+        end
         case argument_metadata[:element][:data_type]
         when "PL/SQL RECORD"
           field_names = record_fields_sorted_by_position(argument_metadata[:element][:fields])

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -239,7 +239,7 @@ describe "Parameter type mapping /" do
     before(:all) do
       plsql.connect! CONNECTION_PARAMS
       @oracle12c_or_higher = !! plsql.connection.select_all(
-      "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 12")
+        "select * from product_component_version where product like 'Oracle%' and to_number(substr(version,1,2)) >= 12")
       skip "Skip until furtuer investigation for #114" if @oracle12c_or_higher
       plsql.execute <<-SQL
         CREATE OR REPLACE FUNCTION test_xmltype


### PR DESCRIPTION
This pull request bumps `TargetRubyVersion: 2.2` since ruby-plsql now only supports Rails 5.0 or higher and address RuboCop offenses.