### PR TITLE
Address incorrect versions in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :test, :development do
   gem "rspec", "~> 3.1"
 
   unless ENV["NO_ACTIVERECORD"]
-    gem "activerecord", ">= 3.2.3", "< 5.2.0"
-    gem "activerecord-oracle_enhanced-adapter", ">= 1.4.1", "< 1.9.0"
+    gem "activerecord", "~> 5.0"
+    gem "activerecord-oracle_enhanced-adapter", "~> 1.7"
     gem "simplecov", ">= 0"
   end
 


### PR DESCRIPTION
https://rubygems.org/gems/ruby-plsql/versions/0.7.0 shows incorrect dependencies:

```
DEVELOPMENT DEPENDENCIES (8):
activerecord < 5.2.0, >= 3.2.3
activerecord-oracle_enhanced-adapter < 1.9.0, >= 1.4.1
```