### PR TITLE
Bump Ruby versions to the latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ install:
 
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
   - 2.2.10
-  - jruby-9.2.0.0
+  - jruby-9.2.3.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* Ruby 2.5.3
https://www.ruby-lang.org/en/news/2018/10/18/ruby-2-5-3-released/

* Ruby 2.4.5
https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-4-5-released/

* Ruby 2.3.8
https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-3-8-released/

* JRuby 9.2.3.0
https://www.jruby.org/2018/11/09/jruby-9-2-3-0.html