### PR TITLE
Fallback to bundler 1.7.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - chmod +x .travis/oracle/download.sh
   - chmod +x .travis/oracle/install.sh
   - chmod +x .travis/setup_accounts.sh
-  - gem install bundler
+  - 'gem install bundler || gem install bundler -v 1.17.3'
 
 install:
   - .travis/oracle/download.sh


### PR DESCRIPTION
Bundler 2 requires Ruby 2.3.0 or higher
https://travis-ci.org/rsim/ruby-plsql/jobs/475857066

```
$ gem install bundler
ERROR:  Error installing bundler:
	bundler requires Ruby version >= 2.3.0.
The command "gem install bundler" failed and exited with 1 during .
```

Refer https://github.com/rails/rails/pull/34851