### PR TITLE
Terminate CI against Ruby 2.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ rvm:
   - 2.5.3
   - 2.4.5
   - 2.3.8
-  - 2.2.10
   - jruby-9.2.3.0
   - ruby-head
   - jruby-head


### PR DESCRIPTION
Ruby 2.2 EOLed last year https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/ .

Technically, CI gets this failure because i18n 1.5.3 requires Ruby 2.3.


https://travis-ci.org/rsim/ruby-plsql/jobs/490337169#L568-L581

```ruby
Gem::InstallError: i18n requires Ruby version >= 2.3.0.
An error occurred while installing i18n (1.5.3), and Bundler cannot continue.
Make sure that `gem install i18n -v '1.5.3' --source 'http://rubygems.org/'`
succeeds before bundling.
In Gemfile:
  activerecord-oracle_enhanced-adapter was resolved to 1.8.2, which depends on
    activerecord was resolved to 5.1.6.1, which depends on
      activemodel was resolved to 5.1.6.1, which depends on
        activesupport was resolved to 5.1.6.1, which depends on
          i18n
The command "bundle install --without=development" failed and exited with 5 during .
Your build has been stopped.
```