### PR TITLE
Bump Ruby versions at CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,11 @@ install:
 
 language: ruby
 rvm:
-  - 2.5.3
-  - 2.4.5
+  - 2.6.3
+  - 2.5.5
+  - 2.4.6
   - 2.3.8
-  - jruby-9.2.3.0
+  - jruby-9.2.7.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
* Ruby 2.6.3
https://www.ruby-lang.org/en/news/2019/04/17/ruby-2-6-3-released/

* Ruby 2.5.5
https://www.ruby-lang.org/en/news/2019/03/15/ruby-2-5-5-released/

* Ruby 2.4.6
https://www.ruby-lang.org/en/news/2019/04/01/ruby-2-4-6-released/

* JRuby 9.2.7.0
https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html