### PR TITLE
CI against Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,16 @@ gemfile:
     - gemfiles/Gemfile.activerecord-5.0
     - gemfiles/Gemfile.activerecord-5.1
     - gemfiles/Gemfile.activerecord-5.2
+    - gemfiles/Gemfile.activerecord-6.0
 
 matrix:
+    exclude:
+       - gemfile: gemfiles/Gemfile.activerecord-6.0
+         rvm: 2.4.6
+       - gemfile: gemfiles/Gemfile.activerecord-6.0
+         rvm: 2.3.8
+       - gemfile: gemfiles/Gemfile.activerecord-6.0
+         rvm: 2.2.10
     allow_failures:
       - rvm: ruby-head
       - rvm: jruby-head

--- a/gemfiles/Gemfile.activerecord-6.0
+++ b/gemfiles/Gemfile.activerecord-6.0
@@ -1,0 +1,21 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'juwelier', '~> 2.0'
+  gem 'rspec_junit_formatter'
+end
+
+group :test, :development do
+  gem 'rake', '>= 10.0'
+  gem 'rspec', '~> 3.1'
+
+  unless ENV['NO_ACTIVERECORD']
+    gem 'activerecord', '~> 6.0.0.rc1'
+    gem 'activerecord-oracle_enhanced-adapter', '~>6.0.0.rc1'
+    gem 'simplecov', '>= 0'
+  end
+
+  platforms :ruby, :mswin, :mingw do
+    gem 'ruby-oci8', '~> 2.1'
+  end
+end


### PR DESCRIPTION
This pull request runs CI against Rails 6.0.0.rc1. Rails 6 requires Ruby 2.5 https://github.com/rails/rails/pull/34754 then Ruby 2.4 or lower versions are excluded.