### PR TITLE
case-insensitive table names and proc params

### DIFF
--- a/lib/plsql/procedure_call.rb
+++ b/lib/plsql/procedure_call.rb
@@ -6,6 +6,11 @@ module PLSQL
       @dbms_output_stream = @schema.dbms_output_stream
       @skip_self = options[:skip_self]
       @self = options[:self]
+
+      if args.size == 1 && args[0].is_a?(Hash) && args[0].keys.all? { |k| k.is_a?(Symbol) }
+        args[0] = args[0].map { |k, v| [k.downcase, v] }.to_h
+      end
+
       @overload = get_overload_from_arguments_list(args)
       @procedure.ensure_tmp_tables_created(@overload) if @procedure.respond_to?(:ensure_tmp_tables_created)
       construct_sql(args)

--- a/lib/plsql/table.rb
+++ b/lib/plsql/table.rb
@@ -172,6 +172,7 @@ module PLSQL
       end
 
       table_proc = TableProcedure.new(@schema, self, :insert)
+      record = record.map { |k, v| [k.downcase.to_sym, v] }.to_h
       table_proc.add_insert_arguments(record)
 
       call = ProcedureCall.new(table_proc, table_proc.argument_values)

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -2358,3 +2358,27 @@ describe "#get_argument_metadata" do
     end
   end
 end
+
+describe "case-insensitive params" do
+  before(:all) do
+    plsql.connect! CONNECTION_PARAMS
+    plsql.execute <<-SQL
+      CREATE OR REPLACE FUNCTION test_func
+        ( p_string VARCHAR2 )
+        RETURN VARCHAR2
+      IS
+      BEGIN
+        RETURN UPPER(p_string);
+      END test_func;
+    SQL
+  end
+
+  after(:all) do
+    plsql.execute "DROP FUNCTION test_func"
+    plsql.logoff
+  end
+
+  it "should call procedure/function with case-insensitive param names" do
+    expect { plsql.test_func(p_STRING: "xxx") }.not_to raise_error
+  end
+end

--- a/spec/plsql/table_spec.rb
+++ b/spec/plsql/table_spec.rb
@@ -215,6 +215,11 @@ describe "Table" do
       expect(plsql.test_employees2.all("ORDER BY employee_id")).to eq(@employees2)
     end
 
+    it "should insert with case-insensetive table name" do
+      plsql.test_employees.insert @employees.first.map { |k, v| [k.upcase.to_sym, v] }.to_h
+      expect(plsql.test_employees.all).to eq([@employees.first])
+    end
+
   end
 
   describe "insert values" do


### PR DESCRIPTION
intent of this PR is to make table names and params in procedures calls case-insensitive