### PR TITLE
Bump RuboCop version to 0.81.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,12 +9,6 @@ AllCops:
 Style/AndOr:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-  EnforcedStyle: context_dependent
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true
@@ -45,7 +39,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
@@ -122,7 +116,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 group :development do
   gem "juwelier", "~> 2.0"
   gem "rspec_junit_formatter"
-  gem "rubocop", require: false
+  gem "rubocop", "0.81", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end


### PR DESCRIPTION
This pull request bumps RuboCop version to 0.81.0.

* Error if RuboCop 0.82.0 or higher
```
% bundle exec rubocop
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
Supported versions: 2.4, 2.5, 2.6, 2.7, 2.8
```

Note: Will consider to drop older Ruby versions at ruby-plsql itself.

* Rename `Layout/IndentFirstArgument` to `Layout/FirstArgumentIndentation`
and `Layout/TrailingBlankLines` to `Layout/TrailingEmptyLines` using mry

```
% gem install mry
mry --target=0.81.0 .rubocop.yml
```

* Remove `Style/BracesAroundHashParameters` cop manually

```
% bundle exec rubocop
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
Error: The `Style/BracesAroundHashParameters` cop has been removed.
(obsolete configuration found in .rubocop.yml, please update it)
```