### PR TITLE
Use OCI driver type for RUBY_ENGINE TruffleRuby

### DIFF
--- a/lib/plsql/connection.rb
+++ b/lib/plsql/connection.rb
@@ -37,8 +37,8 @@ module PLSQL
     end
 
     def self.driver_type #:nodoc:
-      # MRI 1.8.6 or YARV 1.9.1
-      @driver_type ||= if (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby") && defined?(OCI8)
+      # MRI 1.8.6 or YARV 1.9.1 or TruffleRuby
+      @driver_type ||= if (!defined?(RUBY_ENGINE) || RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby") && defined?(OCI8)
         :oci
       # JRuby
       elsif (defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby")


### PR DESCRIPTION
Please use the `:oci` `driver_type` for `TruffleRuby`.  Most `ruby-oci8` tests currently pass and a related PR is submitted here:
https://github.com/kubo/ruby-oci8/pull/225