### PR TITLE
Fixnum and Bignum are deprecated in Ruby 2.4

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -223,8 +223,6 @@ module PLSQL
     end
 
     RUBY_CLASS_TO_SQL_TYPE = {
-      Fixnum => java.sql.Types::INTEGER,
-      Bignum => java.sql.Types::INTEGER,
       Integer => java.sql.Types::INTEGER,
       Float => java.sql.Types::FLOAT,
       BigDecimal => java.sql.Types::NUMERIC,


### PR DESCRIPTION
This pull request addresses these warnings.
https://travis-ci.com/github/rsim/ruby-plsql/jobs/483335621

```
/home/travis/build/rsim/ruby-plsql/lib/plsql/jdbc_connection.rb:225: warning: constant ::Fixnum is deprecated
/home/travis/build/rsim/ruby-plsql/lib/plsql/jdbc_connection.rb:226: warning: constant ::Bignum is deprecated
```

https://github.com/jruby/jruby/issues/4293