### PR TITLE
Replace `NativeException` with `Java::JavaSql::SQLException`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ def get_connection(user_number = 0)
       OCI8.new(database_user, database_password, get_connection_url)
     end
   else
-    try_to_connect(NativeException) do
+    try_to_connect(Java::JavaSql::SQLException) do
       java.sql.DriverManager.getConnection(get_connection_url, database_user, database_password)
     end
   end


### PR DESCRIPTION
This pull request addresses this warning.
https://travis-ci.com/github/rsim/ruby-plsql/jobs/483335621

```
/home/travis/build/rsim/ruby-plsql/spec/spec_helper.rb:88: warning: constant ::NativeException is deprecated
```

Refer https://github.com/rsim/oracle-enhanced/pull/1761/files