### PR TITLE
CI against Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,12 @@ install:
 
 language: ruby
 rvm:
-  - 2.6.3
-  - 2.5.5
-  - 2.4.6
+  - 2.7.3
+  - 2.6.7
+  - 2.5.9
+  - 2.4.10
   - 2.3.8
-  - jruby-9.2.7.0
+  - jruby-9.2.17.0
   - ruby-head
   - jruby-head
 
@@ -46,21 +47,34 @@ gemfile:
     - gemfiles/Gemfile.activerecord-5.1
     - gemfiles/Gemfile.activerecord-5.2
     - gemfiles/Gemfile.activerecord-6.0
-    - gemfiles/Gemfile.activerecord-master
+    - gemfiles/Gemfile.activerecord-6.1
+    - gemfiles/Gemfile.activerecord-main
 
 matrix:
     exclude:
-       - gemfile: gemfiles/Gemfile.activerecord-master
-         rvm: 2.4.6
-       - gemfile: gemfiles/Gemfile.activerecord-master
+       - gemfile: gemfiles/Gemfile.activerecord-main
+         rvm: jruby-9.2.17.0
+       - gemfile: gemfiles/Gemfile.activerecord-main
+         rvm: 2.6.7
+       - gemfile: gemfiles/Gemfile.activerecord-main
+         rvm: 2.5.9
+       - gemfile: gemfiles/Gemfile.activerecord-main
+         rvm: 2.4.10
+       - gemfile: gemfiles/Gemfile.activerecord-main
          rvm: 2.3.8
-       - gemfile: gemfiles/Gemfile.activerecord-master
+       - gemfile: gemfiles/Gemfile.activerecord-main
          rvm: 2.2.10
        - gemfile: gemfiles/Gemfile.activerecord-6.0
-         rvm: 2.4.6
+         rvm: 2.4.10
        - gemfile: gemfiles/Gemfile.activerecord-6.0
          rvm: 2.3.8
        - gemfile: gemfiles/Gemfile.activerecord-6.0
+         rvm: 2.2.10
+       - gemfile: gemfiles/Gemfile.activerecord-6.1
+         rvm: 2.4.10
+       - gemfile: gemfiles/Gemfile.activerecord-6.1
+         rvm: 2.3.8
+       - gemfile: gemfiles/Gemfile.activerecord-6.1
          rvm: 2.2.10
     allow_failures:
       - rvm: ruby-head

--- a/gemfiles/Gemfile.activerecord-6.1
+++ b/gemfiles/Gemfile.activerecord-6.1
@@ -1,0 +1,21 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'juwelier', '~> 2.0'
+  gem 'rspec_junit_formatter'
+end
+
+group :test, :development do
+  gem 'rake', '>= 10.0'
+  gem 'rspec', '~> 3.1'
+
+  unless ENV['NO_ACTIVERECORD']
+    gem 'activerecord', '~> 6.1.0'
+    gem 'activerecord-oracle_enhanced-adapter', '~>6.1.0'
+    gem 'simplecov', '>= 0'
+  end
+
+  platforms :ruby, :mswin, :mingw do
+    gem 'ruby-oci8', '~> 2.1'
+  end
+end

--- a/gemfiles/Gemfile.activerecord-main
+++ b/gemfiles/Gemfile.activerecord-main
@@ -10,7 +10,7 @@ group :test, :development do
   gem 'rspec', '~> 3.1'
 
   unless ENV['NO_ACTIVERECORD']
-    gem 'activerecord',   github: 'rails/rails', branch: 'master'
+    gem 'activerecord',   github: 'rails/rails', branch: 'main'
     gem 'activerecord-oracle_enhanced-adapter', github: 'rsim/oracle-enhanced', branch: 'master'
     gem 'simplecov', '>= 0'
   end


### PR DESCRIPTION
This pull request enables CI against Rails 6.1.

- Bump Ruby versions
- Rails master branch has been renamed to main
- Rails 7 will require Ruby 2.7+
- JRuby 9.7 supports Ruby 2.5 then does not suppport Rails 7 (Rails main branch) yet