### PR TITLE
CI against Ruby 3.0.2, 2.7.4 and 2.6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ install:
 
 language: ruby
 rvm:
-  - 2.7.3
-  - 2.6.7
+  - 3.0.2
+  - 2.7.4
+  - 2.6.8
   - 2.5.9
   - 2.4.10
   - 2.3.8
@@ -57,7 +58,7 @@ matrix:
        - gemfile: gemfiles/Gemfile.activerecord-main
          rvm: jruby-9.2.17.0
        - gemfile: gemfiles/Gemfile.activerecord-main
-         rvm: 2.6.7
+         rvm: 2.6.8
        - gemfile: gemfiles/Gemfile.activerecord-main
          rvm: 2.5.9
        - gemfile: gemfiles/Gemfile.activerecord-main
@@ -81,3 +82,7 @@ matrix:
     allow_failures:
       - rvm: ruby-head
       - rvm: jruby-head
+      - gemfile: gemfiles/Gemfile.activerecord-main
+        rvm: 3.0.2
+      - gemfile: gemfiles/Gemfile.activerecord-main
+        rvm: 2.7.4


### PR DESCRIPTION
* Ruby 3.0.2 Released
https://www.ruby-lang.org/en/news/2021/07/07/ruby-3-0-2-released/

* Ruby 2.7.4 Released
https://www.ruby-lang.org/en/news/2021/07/07/ruby-2-7-4-released/

* Ruby 2.6.8 Released
https://www.ruby-lang.org/en/news/2021/07/07/ruby-2-6-8-released/