### PR TITLE
Run CI with GitHub Actions to support Oracle database 18c

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,69 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        ruby: [
+          3.0,
+          2.7,
+          2.6,
+          2.5,
+          ruby-head,
+          ruby-debug
+        ]
+    env:
+      ORACLE_HOME: /usr/lib/oracle/18.5/client64
+      LD_LIBRARY_PATH: /usr/lib/oracle/18.5/client64/lib
+      NLS_LANG: AMERICAN_AMERICA.AL32UTF8
+      TNS_ADMIN: ./ci/network/admin
+      DATABASE_NAME: XEPDB1
+      TZ: Europe/Riga
+      DATABASE_SYS_PASSWORD: Oracle18
+      DATABASE_VERSION: 18.4.0.0
+
+    services:
+      oracle:
+        image: quillbuilduser/oracle-18-xe
+        ports:
+          - 1521:1521
+        env:
+          TZ: Europe/Riga
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install required package
+      run: |
+        sudo apt-get install alien
+    - name: Download Oracle client
+      run: |
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/185000/oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
+    - name: Install Oracle client
+      run: |
+        sudo alien -i oracle-instantclient18.5-basic-18.5.0.0.0-3.x86_64.rpm
+        sudo alien -i oracle-instantclient18.5-sqlplus-18.5.0.0.0-3.x86_64.rpm
+        sudo alien -i oracle-instantclient18.5-devel-18.5.0.0.0-3.x86_64.rpm
+    - name: Install JDBC Driver
+      run: |
+        cp $ORACLE_HOME/lib/ojdbc8.jar lib/.
+    - name: Create database user
+      run: |
+        ./ci/setup_accounts.sh
+    - name: Bundle install
+      run: |
+        bundle install --jobs 4 --retry 3
+    - name: Run RSpec
+      run: |
+        bundle exec rspec

--- a/ci/network/admin/tnsnames.ora
+++ b/ci/network/admin/tnsnames.ora
@@ -1,0 +1,7 @@
+XEPDB1 =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = 127.0.0.1)(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVICE_NAME = XEPDB1)
+    )
+  )

--- a/ci/setup_accounts.sh
+++ b/ci/setup_accounts.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ev
+
+${ORACLE_HOME}/bin/sqlplus system/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} <<SQL
+@@spec/support/unlock_and_setup_hr_user.sql
+@@spec/support/create_arunit_user.sql
+exit
+SQL

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -1508,6 +1508,12 @@ describe "Parameter type mapping /" do
     end
 
     describe "using Oracle 9.2" do
+      before(:all) do
+        # get actual database_version
+        plsql.connect! CONNECTION_PARAMS
+        skip "Skip if the actual database version is 18c or higher" if (plsql.connection.database_version <=> [18, 0, 0, 0]) >= 0
+      end
+
       before do
         # simulate Oracle 9.2 connection
         plsql(:oracle_9).connection = get_connection


### PR DESCRIPTION
This pull request runs CI with GitHub Actions.

- Run Oracle Database 18c
- Only CRuby versions executed since due to #176
- No Active Record matrix added yet
- Use dbms_session.sleep for Oracle Database 18c or higher
- Skip "using Oracle 9.2" for Oracle Database 18c or higher
