### PR TITLE
Use `gvenzl/oracle-xe` docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,18 @@ jobs:
 
     services:
       oracle:
-        image: quillbuilduser/oracle-18-xe
+        image: gvenzl/oracle-xe:latest
         ports:
           - 1521:1521
         env:
           TZ: Europe/Riga
+          ORACLE_PASSWORD: Oracle18
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/spec/support/unlock_and_setup_hr_user.sql
+++ b/spec/support/unlock_and_setup_hr_user.sql
@@ -1,2 +1,3 @@
-alter user hr identified by hr account unlock;
+create user hr identified by hr;
+grant dba to hr;
 grant execute on dbms_lock to hr;


### PR DESCRIPTION
This pull request runs `gvenzl/oracle-xe` Oracle Database XE Docker image.

- Refer
https://hub.docker.com/r/gvenzl/oracle-xe
https://geraldonit.com/2021/08/15/oracle-xe-docker-images/