### PR TITLE
Restore `alter user hr identified by hr account unlock;`

### DIFF
--- a/spec/support/unlock_and_setup_hr_user.sql
+++ b/spec/support/unlock_and_setup_hr_user.sql
@@ -1,3 +1,4 @@
 create user hr identified by hr;
+alter user hr identified by hr account unlock;
 grant dba to hr;
 grant execute on dbms_lock to hr;


### PR DESCRIPTION
This statement was removed at #201 for GitHub Actions,
which is necessary for Travis CI as follows.

https://app.travis-ci.com/github/rsim/ruby-plsql/jobs/531997440

```
OCIError:
  ORA-28000: the account is locked
```