### PR TITLE
Suppress `assigned but unused variable` warning

### DIFF
--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -231,7 +231,7 @@ module PLSQL
         @object_id, @schema_name, @procedure
       ) do |r|
 
-        subprogram_id, object_name, overload, argument_name, position,
+        subprogram_id, _object_name, overload, argument_name, position,
           data_type, in_out, data_length, data_precision, data_scale, char_used,
           char_length, type_owner, type_name, type_package, type_object_type, defaulted = r
 


### PR DESCRIPTION
Follow up to #196.

This PR suppresses the following `assigned but unused variable` warning.

```console
==> Running specs with ruby version 3.1.0
/home/travis/.rvm/gems/ruby-head/bundler/gems/ruby-plsql-b7f469a72bd7/lib/plsql/procedure.rb:234:
warning: assigned but unused variable - object_name
==> Effective ActiveRecord version 7.0.0.alpha2
```

https://app.travis-ci.com/github/rsim/oracle-enhanced/jobs/550436965