### PR TITLE
CI against Ruby 3.1 at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 
 language: ruby
 rvm:
+  - 3.1.0
   - 3.0.3
   - 2.7.5
   - 2.6.9


### PR DESCRIPTION
* Ruby 3.1.0 Released
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/