### PR TITLE
https://github.com/actions/setup-ruby is deprecated

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Ruby 3.1
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.x
+        ruby-version: "3.1"
     - name: Install required package
       run: |
         sudo apt-get install alien


### PR DESCRIPTION
```
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
```