### PR TITLE
CI against Ruby 3.1.1 at Travis CI #2271

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
 language: ruby
 rvm:
-  - 3.1.0
+  - 3.1.1
   - 3.0.3
   - 2.7.5
   - 2.6.9


### PR DESCRIPTION
* Ruby 3.1.1 Released
https://www.ruby-lang.org/en/news/2022/02/18/ruby-3-1-1-released/