### PR TITLE
Rename the raw connection ivar to `@raw_connection`

### DIFF
--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -289,7 +289,11 @@ module PLSQL
         # ActiveRecord Oracle enhanced adapter puts OCI8EnhancedAutoRecover wrapper around OCI8
         # in this case we need to pass original OCI8 connection
         else
-          raw_connection.instance_variable_get(:@connection)
+          if raw_connection.instance_variable_defined?(:@raw_connection)
+            raw_connection.instance_variable_get(:@raw_connection)
+          else
+            raw_connection.instance_variable_get(:@connection)
+          end
         end
       end
 


### PR DESCRIPTION
This commit addresses these two failures against Rails main branch.
https://app.travis-ci.com/github/rsim/ruby-plsql/jobs/563373660

```ruby
Failures:
  1) DBMS_OUTPUT logging with Activerecord connection should log output to specified stream
     Failure/Error: tdo = raw_oci_connection.get_tdo_by_class(value.class)
     NoMethodError:
       undefined method `get_tdo_by_class' for nil:NilClass
               tdo = raw_oci_connection.get_tdo_by_class(value.class)
                                       ^^^^^^^^^^^^^^^^^
     # ./lib/plsql/oci_connection.rb:263:in `ora_value_to_ruby_value'
     # ./lib/plsql/oci_connection.rb:112:in `[]'
     # ./lib/plsql/procedure_call.rb:602:in `dbms_output_lines'
     # ./lib/plsql/procedure_call.rb:620:in `dbms_output_log'
     # ./lib/plsql/procedure_call.rb:41:in `exec'
     # ./lib/plsql/procedure.rb:546:in `exec'
     # ./lib/plsql/schema.rb:185:in `method_missing'
     # ./spec/plsql/schema_spec.rb:352:in `block (3 levels) in <top (required)>'
  2) DBMS_OUTPUT logging with Activerecord connection should log output after reconnection
     Failure/Error: tdo = raw_oci_connection.get_tdo_by_class(value.class)
     NoMethodError:
       undefined method `get_tdo_by_class' for nil:NilClass
               tdo = raw_oci_connection.get_tdo_by_class(value.class)
                                       ^^^^^^^^^^^^^^^^^
     # ./lib/plsql/oci_connection.rb:263:in `ora_value_to_ruby_value'
     # ./lib/plsql/oci_connection.rb:112:in `[]'
     # ./lib/plsql/procedure_call.rb:602:in `dbms_output_lines'
     # ./lib/plsql/procedure_call.rb:620:in `dbms_output_log'
     # ./lib/plsql/procedure_call.rb:41:in `exec'
     # ./lib/plsql/procedure.rb:546:in `exec'
     # ./lib/plsql/schema.rb:185:in `method_missing'
     # ./spec/plsql/schema_spec.rb:358:in `block (3 levels) in <top (required)>'
Finished in 13.12 seconds (files took 0.35468 seconds to load)
453 examples, 2 failures, 3 pending
```

Related to https://github.com/rsim/oracle-enhanced/pull/2265
Follow up https://github.com/rails/rails/pull/44530