### PR TITLE
Add TruffleRuby to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,9 @@ jobs:
           '2.6',
           '2.5',
           ruby-head,
-          ruby-debug
+          ruby-debug,
+          truffleruby,
+          truffleruby-head
         ]
     env:
       ORACLE_HOME: /usr/lib/oracle/21/client64
@@ -69,6 +71,10 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
+    - name: Disable ActiveRecord for TruffleRuby
+      run: |
+        echo "NO_ACTIVERECORD=true" >> $GITHUB_ENV
+      if: "contains(matrix.ruby, 'truffleruby')"
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,18 @@
 require "rubygems"
 require "bundler"
 Bundler.setup(:default, :development)
-require "simplecov"
 
-SimpleCov.configure do
-  load_profile "root_filter"
-  load_profile "test_frameworks"
-end
+unless ENV["NO_ACTIVERECORD"]
+  require "simplecov"
 
-ENV["COVERAGE"] && SimpleCov.start do
-  add_filter "/.rvm/"
+  SimpleCov.configure do
+    load_profile "root_filter"
+    load_profile "test_frameworks"
+  end
+
+  ENV["COVERAGE"] && SimpleCov.start do
+    add_filter "/.rvm/"
+  end
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))


### PR DESCRIPTION
Please add TruffleRuby to CI to track compatibility.

Since the Gemfile uses an older `1.8.2` version of `activerecord-oracle_enhanced-adapter`, I disabled those tests that rely on this gem, for TruffleRuby only, using the `NO_ACTIVERECORD` environment variable. 
```
       Unsupported Ruby engine truffleruby
     # /home/runner/.rubies/truffleruby-head/lib/gems/gems/activerecord-oracle_enhanced-adapter-1.8.2/lib/active_record/connection_adapters/oracle_enhanced/connection.rb:120:in `<top (required)>'
```