### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby: [
+          '3.2',
           '3.1',
           '3.0',
           '2.7',


### PR DESCRIPTION
This pull request runs CI against Ruby 3.2 at GitHub Actions.