### PR TITLE
Use Ubuntu 20.04 at Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 sudo: required
 
 jdk:


### PR DESCRIPTION
* The Ubuntu 20.04 (Focal Fossa) Build Environment https://docs.travis-ci.com/user/reference/focal/