### PR TITLE
Move rubocop gems to dedicated Bundler group

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,9 +10,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
 
     steps:
     - uses: actions/checkout@v6
@@ -20,19 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "4.0"
-    - name: Create symbolic link for libaio library compatibility
-      run: |
-        sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
-    - name: Download Oracle instant client
-      run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-    - name: Install Oracle instant client
-      run: |
-        sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-
     - name: Build and run RuboCop
       run: |
-        bundle install --jobs 4 --retry 3
-        bundle exec rubocop --parallel
+        BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3
+        BUNDLE_ONLY=rubocop bundle exec rubocop --parallel

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "http://rubygems.org"
 group :development do
   gem "juwelier", "~> 2.0"
   gem "rspec_junit_formatter"
+end
+
+group :rubocop do
   gem "rubocop", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false


### PR DESCRIPTION
## Summary

- Move rubocop, rubocop-performance, and rubocop-rails into a separate `:rubocop` group in the Gemfile
- Use `BUNDLE_ONLY=rubocop` in the RuboCop workflow so Oracle Instant Client is no longer needed for linting

Follows the same pattern as rsim/oracle-enhanced@78d64bd.

## Test plan

- [ ] RuboCop workflow passes without Oracle Instant Client

🤖 Generated with [Claude Code](https://claude.com/claude-code)