### PR TITLE
Move development Ruby builds to daily cron workflows

### DIFF
--- a/.github/workflows/jruby_head.yml
+++ b/.github/workflows/jruby_head.yml
@@ -1,8 +1,8 @@
-name: test
+name: jruby_head
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: "0 1 * * *" # daily at 1:00 UTC
 
 jobs:
   build:
@@ -12,10 +12,7 @@ jobs:
     strategy:
       matrix:
         ruby: [
-          '4.0',
-          '3.4',
-          '3.3',
-          '3.2'
+          jruby-head
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_26
@@ -52,12 +49,10 @@ jobs:
     - name: Download Oracle instant client
       run: |
         wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
         wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
     - name: Install Oracle instant client
       run: |
         sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
         sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
         echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
     - name: Install JDBC Driver

--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -1,8 +1,8 @@
-name: test
+name: ruby_head
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight UTC
 
 jobs:
   build:
@@ -12,10 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby: [
-          '4.0',
-          '3.4',
-          '3.3',
-          '3.2'
+          ruby-head,
+          ruby-debug
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_26
@@ -60,9 +58,6 @@ jobs:
         sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
         sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
         echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
-    - name: Install JDBC Driver
-      run: |
-        wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/233/ojdbc11.jar -O ./lib/ojdbc11.jar
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -15,11 +15,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          '3.2',
-          ruby-head,
-          ruby-debug,
-          truffleruby,
-          truffleruby-head
+          '3.2'
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15
@@ -84,10 +80,6 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
-    - name: Disable ActiveRecord for TruffleRuby
-      run: |
-        echo "NO_ACTIVERECORD=true" >> $GITHUB_ENV
-      if: "contains(matrix.ruby, 'truffleruby')"
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -1,8 +1,8 @@
-name: test
+name: truffleruby
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: "0 2 * * *" # daily at 2:00 UTC
 
 jobs:
   build:
@@ -12,10 +12,8 @@ jobs:
     strategy:
       matrix:
         ruby: [
-          '4.0',
-          '3.4',
-          '3.3',
-          '3.2'
+          truffleruby,
+          truffleruby-head
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_26
@@ -25,6 +23,7 @@ jobs:
       DATABASE_NAME: FREEPDB1
       TZ: Europe/Riga
       DATABASE_SYS_PASSWORD: Oracle18
+      NO_ACTIVERECORD: true
 
     services:
       oracle:
@@ -60,9 +59,6 @@ jobs:
         sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
         sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
         echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
-    - name: Install JDBC Driver
-      run: |
-        wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/233/ojdbc11.jar -O ./lib/ojdbc11.jar
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh


### PR DESCRIPTION
## Summary

- Remove ruby-head, ruby-debug, truffleruby, and truffleruby-head from `test.yml` and `test_11g.yml` so they do not run on every push/PR
- Add dedicated daily cron workflows:
  - `ruby_head.yml`: ruby-head, ruby-debug (daily at midnight UTC)
  - `jruby_head.yml`: jruby-head (daily at 1:00 UTC)
  - `truffleruby.yml`: truffleruby, truffleruby-head (daily at 2:00 UTC)
- Skip Instant Client SDK download in `jruby_head.yml` since JRuby uses JDBC and does not build native extensions
- Skip JDBC driver download in `ruby_head.yml` and `truffleruby.yml` since CRuby and TruffleRuby use OCI

This reduces CI time on every push while still catching regressions against development Ruby builds daily.

## Test plan

- [x] `test.yml` passes with only stable Ruby versions (3.2, 3.3, 3.4, 4.0)
- [x] `test_11g.yml` passes with only stable Ruby versions
- [ ] New cron workflows have valid syntax (verified by push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)