### PR TITLE
Remove DBMS_LOCK grant from shared setup; keep it only for 11g

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -84,6 +84,9 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
+    - name: Grant execute on DBMS_LOCK for Oracle 11g
+      run: |
+        echo "GRANT EXECUTE ON DBMS_LOCK TO hr;" | sqlplus system/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME}
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3

--- a/spec/support/unlock_and_setup_hr_user.sql
+++ b/spec/support/unlock_and_setup_hr_user.sql
@@ -1,4 +1,3 @@
 create user hr identified by hr;
 alter user hr identified by hr account unlock;
 grant dba to hr;
-grant execute on dbms_lock to hr;


### PR DESCRIPTION
## Summary

- Remove `grant execute on dbms_lock to hr` from `spec/support/unlock_and_setup_hr_user.sql`
- Add the grant only to the `test_11g.yml` workflow where Oracle 11g still needs `DBMS_LOCK.SLEEP`

`DBMS_SESSION.SLEEP` (available since Oracle 18c) does not require a separate grant from SYS. The spec already prefers `DBMS_SESSION.SLEEP` on Oracle 18c+ and falls back to `DBMS_LOCK.SLEEP` on older versions, so no spec changes are needed.

## Test plan

- [ ] `test.yml` (Oracle Free 23) passes without the `DBMS_LOCK` grant
- [ ] `test_11g.yml` passes with the `DBMS_LOCK` grant added in the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)