### PR TITLE
Skip test_11g and test_gemfiles for draft pull requests

### DIFF
--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -2,10 +2,14 @@ name: test_11g
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/test_gemfiles.yml
+++ b/.github/workflows/test_gemfiles.yml
@@ -2,7 +2,10 @@ name: test_gemfiles
 
 on:
   push:
+    branches:
+      - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary

- Skip `test_11g.yml` and `test_gemfiles.yml` for draft PRs so only `test.yml` runs for quick feedback
- Run the full CI suite when the PR is marked ready for review
- Limit push triggers to the `master` branch so feature branch pushes only run CI via the `pull_request` event

Follows the same pattern as rsim/oracle-enhanced#2509.

## Test plan

- [ ] Draft PR only triggers `test.yml`
- [ ] Marking the PR as ready for review triggers `test_11g.yml` and `test_gemfiles.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)