### PR TITLE
Use HTTPS for RubyGems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 group :development do
   gem "juwelier", "~> 2.0"


### PR DESCRIPTION
## Summary

- Change Gemfile source from `http://rubygems.org` to `https://rubygems.org` to avoid MITM risk when resolving gems

Spotted by Copilot review on #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)