### PR TITLE
Bump upload-artifact to v7 and download-artifact to v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build gem
         run: gem build ruby-plsql.gemspec
       - name: Upload gem artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gem-cruby
           path: "*.gem"
@@ -39,7 +39,7 @@ jobs:
       actions: read
     steps:
       - name: Download CRuby gem
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gem-cruby
       - name: Set up Ruby


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` from v4 to v7 and `actions/download-artifact` from v4 to v8 in the release workflow
- Fixes Node.js 20 deprecation warnings seen in [release run #24319392558](https://github.com/rsim/ruby-plsql/actions/runs/24319392558)
- Node.js 20 actions will be forced to Node.js 24 starting June 2, 2026

## Test plan
- [ ] Verify the next release workflow run produces no Node.js 20 deprecation annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)