### PR TITLE
Add JRuby support for gem build and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,27 @@ jobs:
           name: gem-cruby
           path: "*.gem"
 
+  build-jruby:
+    name: Build gem (JRuby)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'jruby-10.0.5.0'
+          rubygems: latest
+      - name: Build gem
+        run: gem build ruby-plsql.gemspec
+      - name: Upload gem artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gem-jruby
+          path: "*.gem"
+
   release:
-    name: Push gem to RubyGems
-    needs: [build-cruby]
+    name: Push gems to RubyGems
+    needs: [build-cruby, build-jruby]
     runs-on: ubuntu-latest
     environment: rubygems
     permissions:
@@ -42,6 +60,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gem-cruby
+      - name: Download JRuby gem
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-jruby
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -49,7 +71,7 @@ jobs:
           rubygems: latest
       - name: Configure RubyGems credentials
         uses: rubygems/configure-rubygems-credentials@main
-      - name: Push gem
+      - name: Push gems
         run: |
           for gem in *.gem; do
             echo "Pushing $gem"

--- a/ruby-plsql.gemspec
+++ b/ruby-plsql.gemspec
@@ -23,5 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.1"
   s.add_development_dependency "rspec_junit_formatter"
   s.add_development_dependency "simplecov"
-  s.add_development_dependency "ruby-oci8", "~> 2.1"
+  if RUBY_PLATFORM =~ /java/
+    s.platform = Gem::Platform.new("java")
+  else
+    s.add_runtime_dependency "ruby-oci8", "~> 2.1"
+  end
 end


### PR DESCRIPTION
## Summary
- Add `ruby-oci8` as a runtime dependency only for CRuby (was a dev dependency for all platforms)
- Set gem platform to `java` on JRuby
- Add JRuby build job to the release workflow so both CRuby and JRuby gems are built and pushed

Follows the same approach as rsim/oracle-enhanced@22f0e673cfef13d34cc1fa10fc6eae5d6d89cd34.

## Test plan
- [ ] Verify `gem build ruby-plsql.gemspec` succeeds on both CRuby and JRuby
- [ ] Verify the release workflow builds and pushes both gems

🤖 Generated with [Claude Code](https://claude.com/claude-code)