### PR TITLE
Replace Travis CI badge with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/rsim/ruby-plsql.svg?branch=master)](https://travis-ci.com/rsim/ruby-plsql)
+[![Test](https://github.com/rsim/ruby-plsql/actions/workflows/test.yml/badge.svg)](https://github.com/rsim/ruby-plsql/actions/workflows/test.yml)
 
 ruby-plsql
 ==========


### PR DESCRIPTION
## Summary
- Replace the defunct Travis CI build status badge with a GitHub Actions test workflow badge
- Travis CI support has been dropped; the README should reflect the current CI setup

## Test plan
- [ ] Verify the badge renders correctly and links to the Actions test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)