### PR TITLE
Strip precision from TIMESTAMP data types in %ROWTYPE fields

### DIFF
--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -397,6 +397,9 @@ module PLSQL
 
           col_no, col_name, col_type_name, col_length, col_precision, col_scale, col_char_length, col_char_used = r
 
+          # remove precision (n) from data_type (returned for TIMESTAMPs and INTERVALs)
+          col_type_name = col_type_name.sub(/\(\d+\)/, "")
+
           fields[col_name.downcase.to_sym] = {
             position: col_no.to_i,
             data_type: col_type_name,

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -2427,6 +2427,44 @@ describe "Procedure with %ROWTYPE parameter on table that has hidden columns" do
   end
 end
 
+describe "Function with TIMESTAMP columns in %ROWTYPE" do
+  before(:all) do
+    plsql.connect! CONNECTION_PARAMS
+    plsql.execute "DROP FUNCTION test_timestamp_fn" rescue nil
+    plsql.execute "DROP TABLE test_timestamp_tbl" rescue nil
+    plsql.execute <<-SQL
+      CREATE TABLE test_timestamp_tbl (
+        id NUMBER,
+        ts TIMESTAMP,
+        ts_tz TIMESTAMP WITH TIME ZONE,
+        ts_ltz TIMESTAMP WITH LOCAL TIME ZONE
+      )
+    SQL
+    plsql.execute <<-SQL
+      CREATE OR REPLACE FUNCTION test_timestamp_fn(p_rec test_timestamp_tbl%ROWTYPE)
+        RETURN NUMBER
+      IS
+      BEGIN
+        RETURN p_rec.id;
+      END;
+    SQL
+  end
+
+  after(:all) do
+    plsql.execute "DROP FUNCTION test_timestamp_fn" rescue nil
+    plsql.execute "DROP TABLE test_timestamp_tbl" rescue nil
+    plsql.logoff
+  end
+
+  it "should strip precision from TIMESTAMP data types in %ROWTYPE fields" do
+    procedure = PLSQL::Procedure.find(plsql, :test_timestamp_fn)
+    fields = procedure.arguments[0][:p_rec][:fields]
+    expect(fields[:ts][:data_type]).to eq("TIMESTAMP")
+    expect(fields[:ts_tz][:data_type]).to eq("TIMESTAMP WITH TIME ZONE")
+    expect(fields[:ts_ltz][:data_type]).to eq("TIMESTAMP WITH LOCAL TIME ZONE")
+  end
+end
+
 describe "Function with TABLE OF %ROWTYPE parameter defined in package" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS


### PR DESCRIPTION
## Summary
- `ALL_TAB_COLUMNS.DATA_TYPE` includes precision for TIMESTAMP and INTERVAL types (e.g., `TIMESTAMP(6) WITH LOCAL TIME ZONE`) even when declared without explicit precision (Oracle includes the default precision since at least 11g)
- Strip precision in `get_field_definitions` to match the exact strings expected by type mapping in `oci_connection.rb`, `jdbc_connection.rb`, and `procedure_call.rb`
- Uses the same approach as `table.rb`: `data_type.sub(/\(\d+\)/, "")`

Based on #208

## Test plan
- [ ] Verify `test` workflow passes (Oracle 23c Free)
- [ ] Verify `test_11g` workflow passes (Oracle 11g XE)
- [ ] New test verifies all three TIMESTAMP variants are normalized: `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, `TIMESTAMP WITH LOCAL TIME ZONE`

Co-Authored-By: Jochen Schug <4573581+joschug@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)