### PR TITLE
Use type_owner for cross-schema type lookups

### DIFF
--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -361,7 +361,7 @@ module PLSQL
           WHERE t.OWNER = :owner AND t.type_name = :type_name AND t.package_name = :package_name
           AND ta.OWNER = t.owner AND ta.TYPE_NAME = t.TYPE_NAME AND ta.PACKAGE_NAME = t.PACKAGE_NAME
           ORDER BY attr_no",
-          @schema_name, argument_metadata[:type_name], argument_metadata[:type_subname]) do |r|
+          argument_metadata[:type_owner], argument_metadata[:type_name], argument_metadata[:type_subname]) do |r|
 
           attr_no, attr_name, attr_type_owner, attr_type_name, attr_type_package, attr_length, attr_precision, attr_scale, attr_char_used = r
 
@@ -393,7 +393,7 @@ module PLSQL
           "SELECT column_id, column_name, data_type, data_length, data_precision, data_scale, char_length, char_used
            FROM ALL_TAB_COLUMNS WHERE OWNER = :owner AND TABLE_NAME = :type_name
            ORDER BY column_id",
-          @schema_name, argument_metadata[:type_name]) do |r|
+          argument_metadata[:type_owner], argument_metadata[:type_name]) do |r|
 
           col_no, col_name, col_type_name, col_length, col_precision, col_scale, col_char_length, col_char_used = r
 
@@ -429,7 +429,7 @@ module PLSQL
             "SELECT elem_type_owner, elem_type_name, elem_type_package, length, precision, scale, char_used, index_by
              FROM ALL_PLSQL_COLL_TYPES t
              WHERE t.OWNER = :owner AND t.TYPE_NAME = :type_name AND t.PACKAGE_NAME = :package_name",
-            @schema_name, argument_metadata[:type_name], argument_metadata[:type_subname])
+            argument_metadata[:type_owner], argument_metadata[:type_name], argument_metadata[:type_subname])
 
           elem_type_owner, elem_type_name, elem_type_package, elem_length, elem_precision, elem_scale, elem_char_used, index_by = r
 
@@ -486,7 +486,7 @@ module PLSQL
             "SELECT elem_type_owner, elem_type_name, length, precision, scale, char_used
              FROM ALL_COLL_TYPES t
              WHERE t.owner = :owner AND t.TYPE_NAME = :type_name",
-            @schema_name, argument_metadata[:type_name]
+            argument_metadata[:type_owner], argument_metadata[:type_name]
           )
           elem_type_owner, elem_type_name, elem_length, elem_precision, elem_scale, elem_char_used = r
 

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -2530,3 +2530,48 @@ describe "Function with TABLE OF RECORD parameter defined in package (workaround
     expect(result).to eq(1)
   end
 end
+
+describe "Function with cross-schema type reference" do
+  before(:all) do
+    primary_user, _ = DATABASE_USERS_AND_PASSWORDS[0]
+    second_user, second_password = DATABASE_USERS_AND_PASSWORDS[1]
+    @second_schema = second_user.upcase
+
+    plsql.connect! CONNECTION_PARAMS
+
+    # Connect as second user to create type and grant execute to primary user
+    plsql2 = PLSQL::Schema.new
+    plsql2.connect! CONNECTION_PARAMS.merge(username: second_user, password: second_password)
+    plsql2.execute "CREATE OR REPLACE TYPE t_cross_schema_record AS OBJECT (id NUMBER, name VARCHAR2(50))"
+    plsql2.execute "GRANT EXECUTE ON t_cross_schema_record TO #{primary_user}"
+    plsql2.logoff
+
+    plsql.execute <<-SQL
+      CREATE OR REPLACE FUNCTION test_cross_schema_fn(p_rec #{@second_schema}.t_cross_schema_record)
+        RETURN NUMBER
+      IS
+      BEGIN
+        RETURN p_rec.id;
+      END;
+    SQL
+  end
+
+  after(:all) do
+    second_user, second_password = DATABASE_USERS_AND_PASSWORDS[1]
+    plsql.execute "DROP FUNCTION test_cross_schema_fn" rescue nil
+    plsql2 = PLSQL::Schema.new
+    plsql2.connect! CONNECTION_PARAMS.merge(username: second_user, password: second_password)
+    plsql2.execute "DROP TYPE t_cross_schema_record" rescue nil
+    plsql2.logoff
+    plsql.logoff
+  end
+
+  it "should resolve type from another schema" do
+    expect(PLSQL::Procedure.find(plsql, :test_cross_schema_fn)).not_to be_nil
+  end
+
+  it "should execute function with cross-schema type parameter" do
+    result = plsql.test_cross_schema_fn(id: 42, name: "test")
+    expect(result).to eq(42)
+  end
+end

--- a/spec/support/create_arunit_user.sql
+++ b/spec/support/create_arunit_user.sql
@@ -1,2 +1,5 @@
 create user arunit identified by arunit;
 grant create session to arunit;
+grant create type to arunit;
+grant create procedure to arunit;
+grant unlimited tablespace to arunit;


### PR DESCRIPTION
## Summary
- Use `argument_metadata[:type_owner]` instead of `@schema_name` when querying `ALL_PLSQL_TYPE_ATTRS`, `ALL_TAB_COLUMNS`, `ALL_PLSQL_COLL_TYPES`, and `ALL_COLL_TYPES` in `get_field_definitions` and `get_element_definition`
- This allows types defined in another schema to be resolved correctly for cross-schema type references
- Grant `create type`, `create procedure`, and `unlimited tablespace` to the `arunit` test user for cross-schema testing

## Test plan
- [ ] Verify `test` workflow passes (Oracle 23c Free)
- [ ] Verify `test_11g` workflow passes (Oracle 11g XE)
- [ ] New test: function with cross-schema type parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)