### PR TITLE
Change Dependabot schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Change Dependabot GitHub Actions update check from daily to weekly to reduce noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)