### PR TITLE
Remove unused rspec_junit_formatter dependency

### DIFF
--- a/ruby-plsql.gemspec
+++ b/ruby-plsql.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", ">= 10.0"
   s.add_development_dependency "rspec", "~> 3.1"
-  s.add_development_dependency "rspec_junit_formatter"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "ruby-oci8", "~> 2.1"
 end


### PR DESCRIPTION
## Summary
- Remove `rspec_junit_formatter` from development dependencies
- It was added for Jenkins CI reporting in the 0.6.0 release (2016, #107) but was never configured in Travis CI or GitHub Actions workflows
- No `.rspec` file, spec config, or CI workflow references the junit formatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)