### PR TITLE
Fix TABLE OF %ROWTYPE parameter in package (fixes #200)

### DIFF
--- a/lib/plsql/procedure.rb
+++ b/lib/plsql/procedure.rb
@@ -460,6 +460,23 @@ module PLSQL
 
           if elem_type_package != nil
             element_metadata[:fields] = get_field_definitions(element_metadata)
+          elsif elem_type_name && elem_type_name =~ /\A(.+)%ROWTYPE\z/
+            # TABLE OF table%ROWTYPE: Oracle stores elem_type_name as "TABLE_NAME%ROWTYPE"
+            rowtype_table_name = $1
+            check_owner = elem_type_owner || @schema_name
+            object_type_row = @schema.select_first(
+              "SELECT object_type FROM ALL_OBJECTS WHERE owner = :owner AND object_name = :name AND object_type IN ('TABLE', 'VIEW')",
+              check_owner, rowtype_table_name)
+            if object_type_row
+              element_metadata[:type_owner] ||= check_owner
+              element_metadata[:type_name] = rowtype_table_name
+              element_metadata[:sql_type_name] = build_sql_type_name(check_owner, nil, rowtype_table_name)
+              element_metadata[:data_type] = "PL/SQL RECORD"
+              element_metadata[:type_object_type] = object_type_row[0]
+              element_metadata[:fields] = get_field_definitions(element_metadata)
+            else
+              raise ArgumentError, "Could not resolve #{check_owner}.#{rowtype_table_name} to a table or view for #{elem_type_name}"
+            end
           end
         when "TYPE"
           r = @schema.select_first(

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -2426,3 +2426,69 @@ describe "Procedure with %ROWTYPE parameter on table that has hidden columns" do
     expect(field_names.none? { |name| name.to_s.start_with?("sys_nc") }).to be true
   end
 end
+
+describe "Function with TABLE OF %ROWTYPE parameter defined in package" do
+  before(:all) do
+    plsql.connect! CONNECTION_PARAMS
+    plsql.execute "DROP PACKAGE test_rowtype_pkg" rescue nil
+    plsql.execute "DROP TABLE test_rowtype_tbl" rescue nil
+    plsql.execute "CREATE TABLE test_rowtype_tbl (id NUMBER, name VARCHAR2(50))"
+    plsql.execute <<-SQL
+      CREATE OR REPLACE PACKAGE test_rowtype_pkg IS
+        TYPE t_tab IS TABLE OF test_rowtype_tbl%ROWTYPE;
+        FUNCTION test_fn(p_tab IN t_tab) RETURN NUMBER;
+      END;
+    SQL
+    plsql.execute <<-SQL
+      CREATE OR REPLACE PACKAGE BODY test_rowtype_pkg IS
+        FUNCTION test_fn(p_tab IN t_tab) RETURN NUMBER IS
+        BEGIN
+          RETURN p_tab.COUNT;
+        END;
+      END;
+    SQL
+  end
+
+  after(:all) do
+    plsql.execute "DROP PACKAGE test_rowtype_pkg" rescue nil
+    plsql.execute "DROP TABLE test_rowtype_tbl" rescue nil
+    plsql.logoff
+  end
+
+  it "should execute function with TABLE OF %ROWTYPE parameter" do
+    result = plsql.test_rowtype_pkg.test_fn([{ id: 1, name: "test" }])
+    expect(result).to eq(1)
+  end
+end
+
+describe "Function with TABLE OF RECORD parameter defined in package (workaround for %ROWTYPE)" do
+  before(:all) do
+    plsql.connect! CONNECTION_PARAMS
+    plsql.execute "DROP PACKAGE test_record_pkg" rescue nil
+    plsql.execute <<-SQL
+      CREATE OR REPLACE PACKAGE test_record_pkg IS
+        TYPE t_rec IS RECORD (id NUMBER, name VARCHAR2(50));
+        TYPE t_tab IS TABLE OF t_rec;
+        FUNCTION test_fn(p_tab IN t_tab) RETURN NUMBER;
+      END;
+    SQL
+    plsql.execute <<-SQL
+      CREATE OR REPLACE PACKAGE BODY test_record_pkg IS
+        FUNCTION test_fn(p_tab IN t_tab) RETURN NUMBER IS
+        BEGIN
+          RETURN p_tab.COUNT;
+        END;
+      END;
+    SQL
+  end
+
+  after(:all) do
+    plsql.execute "DROP PACKAGE test_record_pkg" rescue nil
+    plsql.logoff
+  end
+
+  it "should execute function with TABLE OF RECORD parameter" do
+    result = plsql.test_record_pkg.test_fn([{ id: 1, name: "test" }])
+    expect(result).to eq(1)
+  end
+end


### PR DESCRIPTION
## Summary
- Fix `TABLE OF table%ROWTYPE` collection types defined in packages causing `ORA-00911: invalid character` when calling the function
- On Oracle 18c+, the existing code queries [`ALL_PLSQL_COLL_TYPES`](https://docs.oracle.com/en/database/oracle/oracle-database/23/refrn/ALL_PLSQL_COLL_TYPES.html) (introduced in 18c) to resolve collection element types. For `%ROWTYPE` references, Oracle returns `ELEM_TYPE_NAME` as `"TABLE_NAME%ROWTYPE"`. The element was incorrectly treated as OBJECT, causing `ensure_tmp_tables_created` to embed the type name with `%ROWTYPE` literally in DDL
- Detect `%ROWTYPE` suffix in `elem_type_name`, strip it, verify the table via `ALL_OBJECTS`, then populate field definitions from table columns
- On pre-18c databases (e.g. 11g), this code path is not reached because `ALL_ARGUMENTS` expands `%ROWTYPE` into individual fields at deeper data levels

Fixes #200

## Test plan
- [ ] Verify `test` workflow passes (Oracle 23c Free)
- [ ] Verify `test_11g` workflow passes (Oracle 11g XE)
- [ ] New test: function with `TABLE OF %ROWTYPE` parameter in package
- [ ] New test: function with `TABLE OF RECORD` parameter in package (workaround from #200, should continue to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)