### PR TITLE
Fix multiline constant declaration in packages (#207)

### DIFF
--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -9,7 +9,8 @@ module PLSQL
           AND type = 'PACKAGE'
           AND UPPER(text) LIKE :variable_name",
             override_schema_name || schema.schema_name, package, "%#{variable_upcase}%").each do |row|
-        if row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*((:=|DEFAULT).*)?;\s*(--.*)?$/i
+        if row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*((:=|DEFAULT).*)?;\s*(--.*)?$/i ||
+           row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*(:=|DEFAULT)\s*$/i
           return new(schema, variable, package, $2.strip, override_schema_name)
         end
       end

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -340,6 +340,58 @@ describe "Package variables /" do
 
   end
 
+  describe "constants with multiline declaration" do
+    before(:all) do
+      plsql.connect! CONNECTION_PARAMS
+      plsql.execute "DROP PACKAGE test_multiline_pkg" rescue nil
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE test_multiline_pkg IS
+          multiline_constant CONSTANT PLS_INTEGER :=
+            42;
+        END;
+      SQL
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE BODY test_multiline_pkg IS
+        END;
+      SQL
+    end
+
+    after(:all) do
+      plsql.execute "DROP PACKAGE test_multiline_pkg" rescue nil
+      plsql.logoff
+    end
+
+    it "should get constant with multiline assignment" do
+      expect(plsql.test_multiline_pkg.multiline_constant).to eq(42)
+    end
+
+    it "should not match RECORD field as a variable" do
+      begin
+        plsql.execute "DROP PACKAGE test_record_field_pkg" rescue nil
+        plsql.execute <<-SQL
+          CREATE OR REPLACE PACKAGE test_record_field_pkg IS
+            TYPE t_rec IS RECORD (
+              some_field NUMBER,
+              last_field VARCHAR2(50)
+            );
+            rec_var t_rec;
+          END;
+        SQL
+        plsql.execute <<-SQL
+          CREATE OR REPLACE PACKAGE BODY test_record_field_pkg IS
+          END;
+        SQL
+        # last_field is the last field in the RECORD (no trailing comma),
+        # which could falsely match as a variable if the semicolon is optional
+        expect {
+          plsql.test_record_field_pkg.last_field
+        }.to raise_error(/No PL\/SQL procedure or variable 'LAST_FIELD' found/)
+      ensure
+        plsql.execute "DROP PACKAGE test_record_field_pkg" rescue nil
+      end
+    end
+  end
+
   describe "object type" do
     before(:all) do
       plsql.connect! CONNECTION_PARAMS


### PR DESCRIPTION
## Summary
- Fix accessing package constants where the assignment value is wrapped to the next line (e.g., `sys.dbms_db_version.version` on Oracle 19c)
- The regex in `Variable.find` required the semicolon to be on the same line as the declaration, which fails for multiline assignments

Fixes #207

## Test plan
- [ ] Verify `test` workflow passes (Oracle 23c Free)
- [ ] Verify `test_11g` workflow passes (Oracle 11g XE)
- [ ] New test: constant with multiline assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)