### PR TITLE
VALIDATION: verify regression test for #207 fails with naive fix

### DIFF
--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -9,8 +9,7 @@ module PLSQL
           AND type = 'PACKAGE'
           AND UPPER(text) LIKE :variable_name",
             override_schema_name || schema.schema_name, package, "%#{variable_upcase}%").each do |row|
-        if row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*((:=|DEFAULT).*)?;\s*(--.*)?$/i ||
-           row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*(:=|DEFAULT)\s*$/i
+        if row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*((:=|DEFAULT).*)?;?\s*(--.*)?$/i
           return new(schema, variable, package, $2.strip, override_schema_name)
         end
       end

--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -9,7 +9,8 @@ module PLSQL
           AND type = 'PACKAGE'
           AND UPPER(text) LIKE :variable_name",
             override_schema_name || schema.schema_name, package, "%#{variable_upcase}%").each do |row|
-        if row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*((:=|DEFAULT).*)?;\s*(--.*)?$/i
+        if row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*((:=|DEFAULT).*)?;\s*(--.*)?$/i ||
+           row[0] =~ /^\s*#{variable_upcase}\s+(CONSTANT\s+)?([A-Z0-9_. %]+(\([\w\s,]+\))?)\s*(NOT\s+NULL)?\s*(:=|DEFAULT)\s*$/i
           return new(schema, variable, package, $2.strip, override_schema_name)
         end
       end

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -340,6 +340,55 @@ describe "Package variables /" do
 
   end
 
+  describe "constants with multiline declaration" do
+    before(:all) do
+      plsql.connect! CONNECTION_PARAMS
+      plsql.execute "DROP PACKAGE test_multiline_pkg" rescue nil
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE test_multiline_pkg IS
+          multiline_constant CONSTANT PLS_INTEGER :=
+            42;
+        END;
+      SQL
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE BODY test_multiline_pkg IS
+        END;
+      SQL
+    end
+
+    after(:all) do
+      plsql.execute "DROP PACKAGE test_multiline_pkg" rescue nil
+      plsql.logoff
+    end
+
+    it "should get constant with multiline assignment" do
+      expect(plsql.test_multiline_pkg.multiline_constant).to eq(42)
+    end
+
+    it "should not match RECORD field as a variable" do
+      plsql.execute "DROP PACKAGE test_record_field_pkg" rescue nil
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE test_record_field_pkg IS
+          TYPE t_rec IS RECORD (
+            some_field NUMBER,
+            last_field VARCHAR2(50)
+          );
+          rec_var t_rec;
+        END;
+      SQL
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE BODY test_record_field_pkg IS
+        END;
+      SQL
+      # last_field is the last field in the RECORD (no trailing comma),
+      # which could falsely match as a variable if the semicolon is optional
+      expect {
+        plsql.test_record_field_pkg.last_field
+      }.to raise_error(/No PL\/SQL procedure or variable 'LAST_FIELD' found/)
+      plsql.execute "DROP PACKAGE test_record_field_pkg" rescue nil
+    end
+  end
+
   describe "object type" do
     before(:all) do
       plsql.connect! CONNECTION_PARAMS


### PR DESCRIPTION
Temporary PR to validate that the RECORD field regression test fails on both 23c and 11g when using the naive `;?` fix. This PR should NOT be merged.

See #264 for the actual fix.