### PR TITLE
Resolve package SUBTYPE variables to their base types

### DIFF
--- a/lib/plsql/variable.rb
+++ b/lib/plsql/variable.rb
@@ -74,7 +74,13 @@ module PLSQL
             end
             { data_type: typecode, data_length: nil, sql_type_name: "#{type.schema_name}.#{type.type_name}", in_out: "IN/OUT" }
           rescue ArgumentError
-            raise ArgumentError, "Package variable data type #{type_string} is not object type defined in schema"
+            # Try to resolve as a package SUBTYPE
+            base_type = resolve_package_subtype(type_string)
+            if base_type
+              metadata(base_type)
+            else
+              raise ArgumentError, "Package variable data type #{type_string} is not object type defined in schema"
+            end
           end
         when /^(\w+\.)?(\w+)%ROWTYPE$/
           schema = $1 ? plsql.send($1.chop) : plsql
@@ -93,6 +99,34 @@ module PLSQL
         else
           raise ArgumentError, "Package variable data type #{type_string} is not supported"
         end
+      end
+
+      # Resolve a package SUBTYPE to its base type by querying ALL_SOURCE.
+      # Handles both qualified (PACKAGE.SUBTYPE) and unqualified (SUBTYPE) names.
+      def resolve_package_subtype(type_string)
+        if type_string =~ /^(\w+)\.(\w+)$/i
+          # Package-qualified: PACKAGE.SUBTYPE
+          package_name = $1.upcase
+          subtype_name = $2.upcase
+        elsif type_string =~ /^(\w+)$/i
+          # Unqualified: look up in the current package
+          package_name = @package_name
+          subtype_name = $1.upcase
+        else
+          return nil
+        end
+
+        @schema.select_all(
+          "SELECT text FROM all_source
+          WHERE owner = :owner AND name = :package_name AND type = 'PACKAGE'
+            AND UPPER(text) LIKE :subtype_pattern",
+          @schema_name, package_name, "%SUBTYPE%#{subtype_name}%"
+        ).each do |row|
+          if row[0] =~ /^\s*SUBTYPE\s+#{subtype_name}\s+IS\s+([^;]+?)\s*(NOT\s+NULL\s*)?;\s*(--.*)?$/i
+            return $1.strip
+          end
+        end
+        nil
       end
 
       # wrapper class to simulate Procedure class for ProcedureClass#exec

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -340,6 +340,43 @@ describe "Package variables /" do
 
   end
 
+  describe "package subtypes" do
+    before(:all) do
+      plsql.connect! CONNECTION_PARAMS
+      plsql.execute "DROP PACKAGE test_subtype_pkg" rescue nil
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE test_subtype_pkg IS
+          SUBTYPE num_type IS NUMBER(38,0) NOT NULL;
+          SUBTYPE str_type IS VARCHAR2(100);
+          num_var num_type := 42;
+          str_var str_type := 'hello';
+          qualified_var test_subtype_pkg.num_type := 99;
+        END;
+      SQL
+      plsql.execute <<-SQL
+        CREATE OR REPLACE PACKAGE BODY test_subtype_pkg IS
+        END;
+      SQL
+    end
+
+    after(:all) do
+      plsql.execute "DROP PACKAGE test_subtype_pkg" rescue nil
+      plsql.logoff
+    end
+
+    it "should get variable with unqualified subtype" do
+      expect(plsql.test_subtype_pkg.num_var).to eq(42)
+    end
+
+    it "should get VARCHAR2 variable with unqualified subtype" do
+      expect(plsql.test_subtype_pkg.str_var).to eq("hello")
+    end
+
+    it "should get variable with package-qualified subtype" do
+      expect(plsql.test_subtype_pkg.qualified_var).to eq(99)
+    end
+  end
+
   describe "constants with multiline declaration" do
     before(:all) do
       plsql.connect! CONNECTION_PARAMS


### PR DESCRIPTION
## Summary
- Fix accessing package variables declared with a SUBTYPE (e.g., `SUBTYPE num_type IS NUMBER(38,0)`) which raised `ArgumentError`
- Resolve SUBTYPEs to their base types by querying `ALL_SOURCE` for the SUBTYPE definition in the package
- Handles both unqualified (`num_type`) and package-qualified (`package.num_type`) SUBTYPE references

Fixes #223

## Test plan
- [ ] Verify `test` workflow passes (Oracle 23c Free)
- [ ] Verify `test_11g` workflow passes (Oracle 11g XE)
- [ ] New tests: get variables with unqualified SUBTYPE, VARCHAR2 SUBTYPE, and package-qualified SUBTYPE

🤖 Generated with [Claude Code](https://claude.com/claude-code)