### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -25,7 +25,7 @@ begin
     ["./lib"].concat($LOAD_PATH).concat(env_path).detect do |dir|
       # check any compatible JDBC driver in the priority order
       ojdbc_jars.any? do |ojdbc_jar|
-        if File.exists?(file_path = File.join(dir, ojdbc_jar))
+        if File.exist?(file_path = File.join(dir, ojdbc_jar))
           require file_path
           true
         end


### PR DESCRIPTION
## Summary
- Replace `File.exists?` with `File.exist?` in `jdbc_connection.rb`
- `File.exists?` was deprecated in Ruby 2.1 and removed in Ruby 4.0 / JRuby 10.1, causing JDBC driver loading to fail with `NoMethodError: undefined method 'exists?' for class File`

## Test plan
- [ ] Verify JRuby CI passes (jruby-head uses Ruby 4.0 compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)