### PR TITLE
Prefer ActiveRecord.default_timezone over per-class accessor

### DIFF
--- a/lib/plsql/schema.rb
+++ b/lib/plsql/schema.rb
@@ -99,12 +99,15 @@ module PLSQL
         @original_schema.default_timezone
       else
         @default_timezone ||
-          # Use ActiveRecord default_timezone when ActiveRecord connection is used,
-          # preferring the connection's activerecord_class so a subclass override
-          # (available in AR < 8.0) is honored before falling back to the
-          # module-level accessor (AR 7.0+; the only one in AR 8.0+).
-          (@connection && (ar_class = @connection.activerecord_class) &&
-            (ar_class.respond_to?(:default_timezone) ? ar_class.default_timezone : ActiveRecord.default_timezone)) ||
+          # Use ActiveRecord default_timezone when ActiveRecord connection is used.
+          # Prefer the module-level accessor (AR 7.0+; the only one in AR 8.0+) so
+          # that AR 7.0/7.1's deprecation warning for ActiveRecord::Base.default_timezone
+          # is not emitted. Fall back to the per-class accessor only on pre-7.0 AR,
+          # where ActiveRecord.default_timezone does not exist.
+          (@connection && @connection.activerecord_class &&
+            (ActiveRecord.respond_to?(:default_timezone) ?
+              ActiveRecord.default_timezone :
+              @connection.activerecord_class.default_timezone)) ||
           # default to local timezone
           :local
       end

--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -218,6 +218,26 @@ describe "ActiveRecord connection" do
     expect(plsql.default_timezone).to eq(:utc)
   end
 
+  it "should not emit ActiveRecord::Base.default_timezone deprecation warning (#234)" do
+    skip "ActiveRecord.default_timezone is not available" unless ActiveRecord.respond_to?(:default_timezone=)
+
+    original_default_timezone = ActiveRecord.default_timezone
+    ActiveRecord.default_timezone = :utc
+
+    deprecator = ActiveRecord.respond_to?(:deprecator) ? ActiveRecord.deprecator : ActiveSupport::Deprecation
+    original_behavior = deprecator.behavior
+    warnings = []
+    begin
+      deprecator.behavior = ->(message, *) { warnings << message }
+      expect(plsql.default_timezone).to eq(:utc)
+    ensure
+      deprecator.behavior = original_behavior
+      ActiveRecord.default_timezone = original_default_timezone
+    end
+
+    expect(warnings.grep(/default_timezone/)).to be_empty
+  end
+
   it "should have the same connection as default schema" do
     expect(plsql.hr.connection).to eq(plsql.connection)
   end


### PR DESCRIPTION
## Summary
Calling `ar_class.default_timezone` on **Rails 7.0.x** prints

```
DEPRECATION WARNING: ActiveRecord::Base.default_timezone is deprecated
and will be removed in Rails 7.1. Use `ActiveRecord.default_timezone`
instead.
```

even though both accessors return the same value.

Switch the order in `PLSQL::Schema#default_timezone` so that we ask the
module-level `ActiveRecord.default_timezone` first when it is available
(AR 7.0+, and the only accessor left in AR 7.1+) and only fall back to
the per-class accessor on pre-7.0 AR where the module-level one does
not exist.

Fixes #234

## Affected Rails versions
- **Rails 7.0.x** — emits the deprecation warning in user code that configures `plsql.activerecord_class`.
- **Rails 7.1+** — the per-class `ActiveRecord::Base.default_timezone` accessor was removed entirely in commit [rails/rails@96c9db1](https://github.com/rails/rails/commit/96c9db1b4829cb5d2f0e7054bec5a9c6b33f8725) (March 2023). With it gone, `ar_class.respond_to?(:default_timezone)` returns `false` and the existing fallback path in `PLSQL::Schema#default_timezone` already uses `ActiveRecord.default_timezone` — so 7.1/7.2/8.0 users were never seeing the warning. The fix still applies cleanly for them and is a no-op behavior-wise.
- **Rails ≤ 6.x** — `ActiveRecord.default_timezone` doesn't exist; the per-class fallback continues to be used. No behavior change.

## Behavior change
On AR 7.0+, a user who set `MyModel.default_timezone = :utc` (the
deprecated per-class API) and then `plsql.activerecord_class = MyModel`
previously had that per-class override honored. After this change the
module-level `ActiveRecord.default_timezone` is consulted instead and
the per-class override is ignored. This matches the direction Rails
itself is moving (AR 7.1 removed the per-class accessor entirely) and
silences the deprecation warning rather than emulating the deprecated
API.

## Test plan
- [x] Verified by #269 / #271 that the new spec fails on AR 7.0 without
  this fix (deprecation warning surfaces from `lib/plsql/schema.rb:107`)
  and passes on AR 7.1+ with or without the fix (since the deprecated
  accessor is no longer present).
- [ ] Confirm `test_gemfiles` matrix passes on AR 5.0 through AR 8.0.
- [ ] Confirm the deprecation warning no longer appears on AR 7.0 in
  user code that configures `plsql.activerecord_class`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)