### PR TITLE
[verify] #268 test fails without fix (do not merge)

### DIFF
--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -218,6 +218,24 @@ describe "ActiveRecord connection" do
     expect(plsql.default_timezone).to eq(:utc)
   end
 
+  it "should not emit ActiveRecord::Base.default_timezone deprecation warning (#234)" do
+    skip "ActiveRecord.default_timezone is not available" unless ActiveRecord.respond_to?(:default_timezone=)
+
+    ActiveRecord.default_timezone = :utc
+
+    deprecator = ActiveRecord.respond_to?(:deprecator) ? ActiveRecord.deprecator : ActiveSupport::Deprecation
+    original_behavior = deprecator.behavior
+    warnings = []
+    begin
+      deprecator.behavior = ->(message, *) { warnings << message }
+      expect(plsql.default_timezone).to eq(:utc)
+    ensure
+      deprecator.behavior = original_behavior
+    end
+
+    expect(warnings.grep(/default_timezone/)).to be_empty
+  end
+
   it "should have the same connection as default schema" do
     expect(plsql.hr.connection).to eq(plsql.connection)
   end


### PR DESCRIPTION
**Do not merge.** Temporary draft PR to confirm that the regression test added in #268 actually catches the bug from #234.

This branch contains only the test from #268 (without the fix in `lib/plsql/schema.rb`). Expectation:

- `test_gemfiles` matrix entries for **AR 7.0 / 7.1** should fail (they hit the deprecation warning).
- AR 5.x / 6.x entries should `skip` (no `ActiveRecord.default_timezone=`).
- AR 7.2 likely fails (still has the deprecated accessor); AR 8.0 passes (per-class accessor removed).

Once observed, this PR will be closed.