### PR TITLE
Set continue-on-error: false for ruby_head and truffleruby workflows

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -8,7 +8,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       matrix:
         ruby: [

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -8,7 +8,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     strategy:
       matrix:
         ruby: [


### PR DESCRIPTION
## Summary
Flip `continue-on-error` from `true` to `false` on the `ruby_head` and `truffleruby` scheduled workflows so that a failed CI job actually fails the suite.

In practice, `continue-on-error: true` makes job results "green even when red" and failures under that mode tend to get ignored — defeating the purpose of running the job at all. We'd rather see a real red status when a head/preview Ruby genuinely breaks.

A companion change for the PR-gating workflows (`test`, `test_11g`, `test_11g_ojdbc11`, `jruby_head`) is in #259.

## Test plan
- [ ] CI runs and any preexisting head/preview failures now surface as real failures (rather than being masked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)