### PR TITLE
[verify] #268 test fails without fix on rebased master (do not merge)

### DIFF
--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -218,6 +218,24 @@ describe "ActiveRecord connection" do
     expect(plsql.default_timezone).to eq(:utc)
   end
 
+  it "should not emit ActiveRecord::Base.default_timezone deprecation warning (#234)" do
+    skip "ActiveRecord.default_timezone is not available" unless ActiveRecord.respond_to?(:default_timezone=)
+
+    ActiveRecord.default_timezone = :utc
+
+    deprecator = ActiveRecord.respond_to?(:deprecator) ? ActiveRecord.deprecator : ActiveSupport::Deprecation
+    original_behavior = deprecator.behavior
+    warnings = []
+    begin
+      deprecator.behavior = ->(message, *) { warnings << message }
+      expect(plsql.default_timezone).to eq(:utc)
+    ensure
+      deprecator.behavior = original_behavior
+    end
+
+    expect(warnings.grep(/default_timezone/)).to be_empty
+  end
+
   it "should have the same connection as default schema" do
     expect(plsql.hr.connection).to eq(plsql.connection)
   end


### PR DESCRIPTION
**Do not merge.** Verification PR for #268.

This branch contains only the regression test from #268 (without the fix in `lib/plsql/schema.rb`), rebased on top of the new master after #259 was merged.

## Expected results

| AR version | Expectation | Why |
|---|---|---|
| **7.0.x** | **fail** | `ActiveRecord::Base.default_timezone` exists as a deprecated proxy that prints `"is deprecated and will be removed in Rails 7.1"` before forwarding to `ActiveRecord.default_timezone`. The OLD code path in `PLSQL::Schema#default_timezone` calls the per-class accessor and the deprecation fires; the test captures the warning and asserts it shouldn't be there. |
| 7.1+ | pass | Rails removed `ActiveRecord::Base.default_timezone` entirely in [rails/rails@96c9db1](https://github.com/rails/rails/commit/96c9db1b4829cb5d2f0e7054bec5a9c6b33f8725) (March 2023, shipped in 7.1). With the per-class accessor gone, `ar_class.respond_to?(:default_timezone)` returns `false` and the OLD code already falls through to `ActiveRecord.default_timezone` — no warning. |
| 7.2 / 8.0 | pass | Same as 7.1. |
| 5.x / 6.x | skip | `ActiveRecord` doesn't `respond_to?(:default_timezone=)`, so the test skips before exercising any code under test. |

## Observed (CI on this PR)

- AR 7.0: ❌ failed at `schema_spec.rb:221` with the exact deprecation message from #234.
- AR 7.1, 7.2, 8.0: ✅ passed.
- AR 5.x, 6.x: skipped as expected.

This confirms #268's test correctly catches the bug on Rails 7.0.x. PR will be closed without merging.