### PR TITLE
Remove unused result_new local in get_ruby_value_from_result_set

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -378,7 +378,7 @@ module PLSQL
     def get_ruby_value_from_result_set(rset, i, metadata)
       ruby_type = SQL_TYPE_TO_RUBY_CLASS[metadata[:sql_type]]
       ora_value = get_bind_variable(rset, i, ruby_type)
-      result_new = ora_value_to_ruby_value(ora_value)
+      ora_value_to_ruby_value(ora_value)
     end
 
     def result_set_to_ruby_data_type(column_type, column_type_name)


### PR DESCRIPTION
## Summary
- `get_ruby_value_from_result_set` assigned its return value to a local `result_new` that was never read.
- Under `RUBYOPT=-w` (seen on the JRuby head CI job) this produced `lib/plsql/jdbc_connection.rb:381: warning: assigned but unused variable - result_new`.
- Drop the assignment and return the expression directly; no behavior change (the caller at `lib/plsql/jdbc_connection.rb:222` still receives the converted Ruby value).

## Test plan
- [x] `ruby -c lib/plsql/jdbc_connection.rb` passes.
- [ ] Re-run CI (including JRuby head) and confirm the `jdbc_connection.rb:381` warning is gone.
- [ ] Cursor-exercising specs (e.g. `spec/plsql/procedure_spec.rb`, `spec/plsql/sql_statements_spec.rb`) still pass against a live Oracle DB.

Remaining warnings in that CI run originate from activesupport / activerecord / JRuby and are out of scope for this repo.

Generated with [Claude Code](https://claude.com/claude-code)