### PR TITLE
Bump JRuby from 10.0.5.0 to 10.1.0.0 in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-10.0.5.0'
+          ruby-version: 'jruby-10.1.0.0'
           rubygems: latest
       - name: Build gem
         run: gem build ruby-plsql.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           '3.4',
           '3.3',
           '3.2',
-          'jruby-10.0.5.0',
+          'jruby-10.1.0.0',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_23_26

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -20,7 +20,7 @@ jobs:
           '3.4',
           '3.3',
           '3.2',
-          'jruby-10.0.5.0',
+          'jruby-10.1.0.0',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: [
-          'jruby-10.0.5.0'
+          'jruby-10.1.0.0'
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_15


### PR DESCRIPTION
## Summary

- Bumps the pinned JRuby version from `jruby-10.0.5.0` to `jruby-10.1.0.0` in all CI workflow files (`test.yml`, `test_11g.yml`, `test_11g_ojdbc11.yml`, `release.yml`).
- `jruby_head.yml` is unchanged as it tracks `jruby-head`.

## References

- JRuby 10.1.0.0 release announcement: https://www.jruby.org/2026/04/21/jruby-10-1-0-0.html
- `ruby/setup-ruby` support: https://github.com/ruby/setup-ruby/pull/906

## Test plan

- [ ] `test.yml` matrix job for `jruby-10.1.0.0` passes
- [ ] `test_11g.yml` matrix job for `jruby-10.1.0.0` passes
- [ ] `test_11g_ojdbc11.yml` job for `jruby-10.1.0.0` passes
- [ ] `release.yml` gem build step on `jruby-10.1.0.0` completes
