### PR TITLE
Bump Oracle Instant Client to the latest versions

### DIFF
--- a/.github/workflows/jruby_head.yml
+++ b/.github/workflows/jruby_head.yml
@@ -15,8 +15,6 @@ jobs:
           jruby-head
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -53,16 +51,19 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
     - name: Install Oracle instant client
       run: |
-        sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+        ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+        echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "$ORACLE_HOME" >> $GITHUB_PATH
     - name: Install JDBC Driver
       run: |
-        wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
+        cp "$ORACLE_HOME/ojdbc17.jar" ./lib/ojdbc17.jar
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -16,8 +16,6 @@ jobs:
           ruby-debug
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -49,15 +47,18 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
     - name: Install Oracle instant client
       run: |
-        sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+        ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+        echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "$ORACLE_HOME" >> $GITHUB_PATH
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
           'jruby-10.0.5.0',
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -58,19 +56,22 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
     - name: Install Oracle instant client
       run: |
-        sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+        ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+        echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "$ORACLE_HOME" >> $GITHUB_PATH
     - name: Install JDBC Driver
       if: startsWith(matrix.ruby, 'jruby')
       run: |
-        wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
+        cp "$ORACLE_HOME/ojdbc17.jar" ./lib/ojdbc17.jar
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -23,8 +23,8 @@ jobs:
           'jruby-10.0.5.0',
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_21_15
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_15
+      ORACLE_HOME: /opt/oracle/instantclient_21_21
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_21
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -62,26 +62,26 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-basic-linux.x64-21.15.0.0.0dbru.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-basic-linux.x64-21.21.0.0.0dbru.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip
     - name: Install Oracle instant client
       run: |
         sudo mkdir -p /opt/oracle/
-        sudo unzip -q instantclient-basic-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-        sudo unzip -qo instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-        sudo unzip -qo instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-        echo "/opt/oracle/instantclient_21_15" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+        sudo unzip -qo instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+        sudo unzip -qo instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+        echo "/opt/oracle/instantclient_21_21" >> $GITHUB_PATH
     - name: Install JDBC Driver
       if: startsWith(matrix.ruby, 'jruby')
       run: |
         wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc17.jar -O ./lib/ojdbc17.jar
     - name: Configure ORA_TZFILE to match Oracle 11g server
       run: |
-        # Oracle 11g XE uses timezone file v14; Instant Client 21.15 embeds
-        # v35. This mismatch causes ORA-01805 when fetching DATE/TIMESTAMP
-        # values. Copy the v14 files from the 11g container and point the
-        # Instant Client at them via ORA_TZFILE.
+        # Oracle 11g XE uses timezone file v14; the 21.x Instant Client
+        # embeds a newer file. The mismatch causes ORA-01805 when fetching
+        # DATE/TIMESTAMP values. Copy the v14 files from the 11g container
+        # and point the Instant Client at them via ORA_TZFILE.
         ORACLE_CONTAINER="${{ job.services.oracle.id }}"
         sudo mkdir -p "$ORACLE_HOME/oracore/zoneinfo"
         docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezlrg_14.dat /tmp/timezlrg_14.dat

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -19,8 +19,8 @@ jobs:
           'jruby-10.0.5.0'
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_21_15
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_15
+      ORACLE_HOME: /opt/oracle/instantclient_21_21
+      LD_LIBRARY_PATH: /opt/oracle/instantclient_21_21
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: XE
@@ -57,25 +57,25 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-basic-linux.x64-21.15.0.0.0dbru.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2115000/instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-basic-linux.x64-21.21.0.0.0dbru.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/2121000/instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip
     - name: Install Oracle instant client
       run: |
         sudo mkdir -p /opt/oracle/
-        sudo unzip -q instantclient-basic-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-        sudo unzip -qo instantclient-sqlplus-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-        sudo unzip -qo instantclient-sdk-linux.x64-21.15.0.0.0dbru.zip -d /opt/oracle
-        echo "/opt/oracle/instantclient_21_15" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+        sudo unzip -qo instantclient-sqlplus-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+        sudo unzip -qo instantclient-sdk-linux.x64-21.21.0.0.0dbru.zip -d /opt/oracle
+        echo "/opt/oracle/instantclient_21_21" >> $GITHUB_PATH
     - name: Install JDBC Driver
       run: |
-        wget -q https://download.oracle.com/otn-pub/otn_software/jdbc/23261/ojdbc11.jar -O ./lib/ojdbc11.jar
+        cp "$ORACLE_HOME/ojdbc11.jar" ./lib/ojdbc11.jar
     - name: Configure ORA_TZFILE to match Oracle 11g server
       run: |
-        # Oracle 11g XE uses timezone file v14; Instant Client 21.15 embeds
-        # v35. This mismatch causes ORA-01805 when fetching DATE/TIMESTAMP
-        # values. Copy the v14 files from the 11g container and point the
-        # Instant Client at them via ORA_TZFILE.
+        # Oracle 11g XE uses timezone file v14; the 21.x Instant Client
+        # embeds a newer file. The mismatch causes ORA-01805 when fetching
+        # DATE/TIMESTAMP values. Copy the v14 files from the 11g container
+        # and point the Instant Client at them via ORA_TZFILE.
         ORACLE_CONTAINER="${{ job.services.oracle.id }}"
         sudo mkdir -p "$ORACLE_HOME/oracore/zoneinfo"
         docker cp "$ORACLE_CONTAINER":/u01/app/oracle/product/11.2.0/xe/oracore/zoneinfo/timezlrg_14.dat /tmp/timezlrg_14.dat

--- a/.github/workflows/test_gemfiles.yml
+++ b/.github/workflows/test_gemfiles.yml
@@ -40,8 +40,6 @@ jobs:
             ruby: '3.2'
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -73,15 +71,18 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
     - name: Install Oracle instant client
       run: |
-        sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+        ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+        echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "$ORACLE_HOME" >> $GITHUB_PATH
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -16,8 +16,6 @@ jobs:
           truffleruby-head
         ]
     env:
-      ORACLE_HOME: /opt/oracle/instantclient_23_26
-      LD_LIBRARY_PATH: /opt/oracle/instantclient_23_26
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8
       TNS_ADMIN: ./ci/network/admin
       DATABASE_NAME: FREEPDB1
@@ -50,15 +48,18 @@ jobs:
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     - name: Download Oracle instant client
       run: |
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-basic-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sdk-linux.x64-23.26.1.0.0.zip
-        wget -q https://download.oracle.com/otn_software/linux/instantclient/2326100/instantclient-sqlplus-linux.x64-23.26.1.0.0.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip
+        wget -q https://download.oracle.com/otn_software/linux/instantclient/instantclient-sqlplus-linuxx64.zip
     - name: Install Oracle instant client
       run: |
-        sudo unzip -q instantclient-basic-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sdk-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        sudo unzip -qo instantclient-sqlplus-linux.x64-23.26.1.0.0.zip -d /opt/oracle/
-        echo "/opt/oracle/instantclient_23_26" >> $GITHUB_PATH
+        sudo unzip -q instantclient-basic-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sdk-linuxx64.zip -d /opt/oracle/
+        sudo unzip -qo instantclient-sqlplus-linuxx64.zip -d /opt/oracle/
+        ORACLE_HOME=$(find /opt/oracle -name "instantclient_*" -type d | head -1)
+        echo "ORACLE_HOME=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$ORACLE_HOME" >> $GITHUB_ENV
+        echo "$ORACLE_HOME" >> $GITHUB_PATH
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -1875,7 +1875,7 @@ describe "Parameter type mapping /" do
       expect(plsql.test_cursor do |cursor|
         cursor2 = cursor
       end).to be_nil
-      expect { cursor2.fetch }.to raise_error(/Cursor was already closed|Closed Statement|Closed ResultSet/)
+      expect { cursor2.fetch }.to raise_error(/Cursor was already closed|Closed Statement|Closed ResultSet/i)
     end
 
     it "should not raise error if cursor is closed inside block" do


### PR DESCRIPTION
## Summary

Mirror rsim/oracle-enhanced#2621 for the ruby-plsql CI workflows:

- Switch the modern (23.x) workflows (`test`, `ruby_head`, `jruby_head`, `truffleruby`, `test_gemfiles`) to Oracle's version-less Instant Client download URLs so we automatically pick up new 23.x minors. `ORACLE_HOME` / `LD_LIBRARY_PATH` / `PATH` are derived dynamically from the extracted directory, so the workflows no longer hard-code `instantclient_23_26`.
- Bump the 11g compatibility workflows (`test_11g`, `test_11g_ojdbc11`) from `21.15.0.0.0dbru` to `21.21.0.0.0dbru` (latest 21.x). Oracle does not publish a version-less 21.x URL, so this line still requires an explicit pin. The inline `ORA_TZFILE` comment was reworded so it does not stale on future bumps.
- Drop the redundant `/jdbc/23261/ojdbc{11,17}.jar` wgets where the Instant Client zip already ships the matching driver (`test.yml`, `jruby_head.yml`, `test_11g_ojdbc11.yml`). The single download that remains is `test_11g.yml`'s `ojdbc17.jar`, because the 21.x zip does not include `ojdbc17.jar` and Oracle has no version-less JDBC URL.

## Test plan

- [ ] `test` matrix passes with the version-less 23.x download
- [ ] `test_11g` matrix passes against the new `21.21.0.0.0dbru` pin
- [ ] `test_11g_ojdbc11` passes with the `cp $ORACLE_HOME/ojdbc11.jar` shortcut
- [ ] `test_gemfiles` passes
- [ ] Scheduled-only runs (`ruby_head`, `jruby_head`, `truffleruby`) exercise the version-less 23.x download after merge