### PR TITLE
Update README Ruby and Oracle versions to match CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ or include gem in Gemfile if using bundler.
 In addition install either ruby-oci8 (for MRI/YARV) or copy Oracle JDBC driver to $JRUBY_HOME/lib (for JRuby).
 
 If you are using MRI Ruby implementation then you need to install ruby-oci8 gem (version 2.1 or higher)
-as well as Oracle client, e.g. [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html).
+as well as Oracle client, e.g. [Oracle Instant Client](https://www.oracle.com/database/technologies/instant-client/downloads.html).
 
 If you are using JRuby then you need to download the appropriate [Oracle JDBC driver](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html) for your Java version. CI exercises ojdbc17.jar and ojdbc11.jar on Java 21.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ruby-plsql gem provides simple Ruby API for calling Oracle PL/SQL procedures. It
 
 NUMBER, BINARY_INTEGER, PLS_INTEGER, NATURAL, NATURALN, POSITIVE, POSITIVEN, SIGNTYPE, SIMPLE_INTEGER, VARCHAR, VARCHAR2, NVARCHAR2, CHAR, NCHAR, DATE, TIMESTAMP, CLOB, BLOB, BOOLEAN, PL/SQL RECORD, TABLE, VARRAY, OBJECT and CURSOR types are supported for input and output parameters and return values of PL/SQL procedures and functions.
 
-ruby-plsql supports Ruby 2.2, 2.3, 2.4, 2.5 (ruby-oci8 2.2.3+ is needed for Ruby 2.4) and JRuby 9.1 implementations.
+ruby-plsql is tested on CI against Ruby 2.4, 2.5, 2.7, 3.1, 3.2, 3.3, 3.4, 4.0 and JRuby 10.1.0.0. Ruby 2.4–3.1 remain in CI to verify compatibility with older ActiveRecord releases (see gemfiles/). The CI runs the suite against Oracle Database 23ai Free and Oracle Database XE 11g.
 
 USAGE
 -----
@@ -154,7 +154,7 @@ In addition install either ruby-oci8 (for MRI/YARV) or copy Oracle JDBC driver t
 If you are using MRI Ruby implementation then you need to install ruby-oci8 gem (version 2.1 or higher)
 as well as Oracle client, e.g. [Oracle Instant Client](http://www.oracle.com/technetwork/database/features/instant-client/index-097480.html).
 
-If you are using JRuby then you need to download the appropriate [Oracle JDBC driver](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html) for your Java version - ojdbc17.jar for Java 17+, ojdbc11.jar for Java 11+, ojdbc8.jar for Java 8+, ojdbc7.jar for Java 7, ojdbc6.jar for Java 6, or ojdbc5.jar for Java 5.
+If you are using JRuby then you need to download the appropriate [Oracle JDBC driver](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html) for your Java version. CI exercises ojdbc17.jar and ojdbc11.jar on Java 21.
 
 And copy this file to one of these locations. JDBC driver will be searched in this order:
 


### PR DESCRIPTION
## Summary
- Replace the stale "supports Ruby 2.2–2.5 and JRuby 9.1" line with what CI actually exercises: Ruby 2.4, 2.5, 2.7, 3.1, 3.2, 3.3, 3.4, 4.0 and JRuby 10.1.0.0. Note that 2.4–3.1 remain only to verify older ActiveRecord releases (`gemfiles/`).
- Add the Oracle Database versions covered on CI: 23ai Free (`gvenzl/oracle-free`) and XE 11g (`gvenzl/oracle-xe`).
- Trim the JDBC driver list (which previously listed ojdbc5–17) down to what CI exercises: ojdbc17.jar and ojdbc11.jar on Java 21.
- Phrasing intentionally uses "tested on CI against …" rather than "supports …", since older Ruby/Java/Oracle/JDBC combinations are untested rather than explicitly dropped.

## Test plan
- [ ] Verify the rendered README on GitHub reads naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)