### PR TITLE
Grant execute on dbms_lock as SYS

### DIFF
--- a/ci/setup_accounts.sh
+++ b/ci/setup_accounts.sh
@@ -7,3 +7,12 @@ sqlplus system/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} <<SQL
 @@spec/support/create_arunit_user.sql
 exit
 SQL
+
+# `grant execute on dbms_lock` requires SYS in 12c+; SYSTEM no longer has the
+# privilege. Run it through a separate `as sysdba` session so the same script
+# works on both gvenzl/oracle-xe:11 and gvenzl/oracle-free.
+sqlplus -s sys/${DATABASE_SYS_PASSWORD}@${DATABASE_NAME} as sysdba <<SQL
+whenever sqlerror exit failure
+grant execute on dbms_lock to hr;
+exit
+SQL

--- a/spec/support/unlock_and_setup_hr_user.sql
+++ b/spec/support/unlock_and_setup_hr_user.sql
@@ -1,4 +1,3 @@
 create user hr identified by hr;
 alter user hr identified by hr account unlock;
 grant dba to hr;
-grant execute on dbms_lock to hr;


### PR DESCRIPTION
## Summary

- Since Oracle 12c, `SYSTEM` cannot grant `EXECUTE` on SYS-owned packages like `DBMS_LOCK`; only `SYS` (or a user with `GRANT ANY OBJECT PRIVILEGE`) can. The grant in `spec/support/unlock_and_setup_hr_user.sql` therefore fails on `gvenzl/oracle-free` with `ORA-01031: insufficient privileges`. `sqlplus` does not propagate the error, so the failure has been silently logged in CI runs (see for example [run 25378360238 / job 74419513314](https://github.com/rsim/ruby-plsql/actions/runs/25378360238/job/74419513314?pr=276)).
- The `hr` user happens not to need `DBMS_LOCK` on modern Oracle: the threaded-cursor spec in `spec/plsql/schema_spec.rb:255` uses `DBMS_SESSION.sleep` on 18c+ and only falls back to `DBMS_LOCK.sleep` on older versions, so the grant only matters for the 11g matrix.
- Move the grant into a separate `as sysdba` `sqlplus` session in `ci/setup_accounts.sh` so it succeeds on both `gvenzl/oracle-xe:11` and `gvenzl/oracle-free`, and add `whenever sqlerror exit failure` so any future grant failure surfaces instead of being hidden.

## Test plan

- [ ] `.github/workflows/test.yml` (gvenzl/oracle-free 23c) passes with no `ORA-01031` line in the "Create database user" step.
- [ ] `.github/workflows/test_11g.yml` (gvenzl/oracle-xe:11) passes — confirms the as-sysdba grant works on 11g and the threaded-cursor spec that uses `DBMS_LOCK.sleep` still has access.
- [ ] `.github/workflows/devcontainer.yml` passes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)