### PR TITLE
Speed up two slowest specs (~2.2s combined)

### DIFF
--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -352,7 +352,7 @@ describe "DBMS_OUTPUT logging" do
 
     it "should log output when database version is less than 10.2" do
       allow(plsql.connection).to receive(:database_version).and_return([9, 2, 0, 0])
-      times = 2_000
+      times = 100
       plsql.test_dbms_output_large("1234567890", times)
       expect(@buffer.string).to eq("DBMS_OUTPUT: 1234567890\n" * times)
     end

--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -255,14 +255,14 @@ describe "ActiveRecord connection" do
   it "should safely close cursors in threaded environment" do
     if (plsql.connection.database_version <=> [18, 0, 0, 0]) >= 0
       expect {
-        t1 = Thread.new { plsql.dbms_session.sleep(1) }.tap { |t| t.abort_on_exception = true }
-        t2 = Thread.new { plsql.dbms_session.sleep(2) }.tap { |t| t.abort_on_exception = true }
+        t1 = Thread.new { plsql.dbms_session.sleep(0.1) }.tap { |t| t.abort_on_exception = true }
+        t2 = Thread.new { plsql.dbms_session.sleep(0.2) }.tap { |t| t.abort_on_exception = true }
         [t2, t1].each { |t| t.join }
       }.not_to raise_error
     else
       expect {
-        t1 = Thread.new { plsql.dbms_lock.sleep(1) }.tap { |t| t.abort_on_exception = true }
-        t2 = Thread.new { plsql.dbms_lock.sleep(2) }.tap { |t| t.abort_on_exception = true }
+        t1 = Thread.new { plsql.dbms_lock.sleep(0.1) }.tap { |t| t.abort_on_exception = true }
+        t2 = Thread.new { plsql.dbms_lock.sleep(0.2) }.tap { |t| t.abort_on_exception = true }
         [t2, t1].each { |t| t.join }
       }.not_to raise_error
     end


### PR DESCRIPTION
## Summary

Two independent test-only changes that bring the spec suite from ~9.93s down to ~7.7s, with a much flatter slowest-examples profile afterwards.

### 1. Threaded-cursor spec — drop sleep durations

`should safely close cursors in threaded environment` (`spec/plsql/schema_spec.rb:255`) spawns two threads that call `DBMS_SESSION.sleep` (or `DBMS_LOCK.sleep` on pre-18c) and joins them. The point is that two concurrent calls on the same connection don't trip the cursor pool — the sleep durations are only there to keep both calls in flight at once.

The original 1s / 2s sleeps dominated the suite at ~2.05s (the slowest example by a wide margin). Drop to 0.1s / 0.2s — that still keeps both threads in flight for 100ms with a 100ms ordering gap, far more than OS scheduling needs.

Result: this example: ~2.05s → ~0.29s (verified stable across 3 back-to-back runs).

### 2. Pre-10.2 dbms_output spec — drop iteration count

`should log output when database version is less than 10.2` (`spec/plsql/schema_spec.rb:353`) stubs `database_version` to `[9, 2, 0, 0]` so dbms_output retrieval falls into the per-line `DBMS_OUTPUT.GET_LINE` loop in `PLSQL::ProcedureCall#dbms_output_lines` instead of the batched `GET_LINES` path used on 10.2+. With `times = 2_000` each iteration is one parse-and-exec round-trip.

The intent of the example is to verify the alternate per-line code path works at all — 100 iterations exercise it just as well as 2_000 (the buffer-size assertions live in the unmocked examples right above).

Result: ~0.42s → ~0.09s (verified stable across 3 runs).

## Combined impact

- Full suite locally: ~9.93s → ~7.7s.
- Slowest-examples profile is now flat — top spec is ~0.33s, everything bunched together.

## Test plan

- [ ] CI green — both specs continue to verify the same code paths they did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)