### PR TITLE
Drop stale describe_synonym comment

### DIFF
--- a/lib/plsql/connection.rb
+++ b/lib/plsql/connection.rb
@@ -179,8 +179,6 @@ module PLSQL
       end
     end
 
-    # all_synonyms view is quite slow therefore
-    # this implementation is overriden in OCI connection with faster native OCI method
     def describe_synonym(schema_name, synonym_name) # :nodoc:
       select_first(
         "SELECT table_owner, table_name FROM all_synonyms WHERE owner = :owner AND synonym_name = :synonym_name",


### PR DESCRIPTION
## Summary

Both lines of the comment above `PLSQL::Connection#describe_synonym` (`lib/plsql/connection.rb:182-183`) are no longer accurate:

- **"all_synonyms view is quite slow"** — measured against Oracle 23ai with a 1500-synonym fixture (500 each of table-, function-, and package-targeting synonyms), this method is ~0.43 ms/call, dominated by the network round-trip rather than the dictionary-view query. A `DBMS_UTILITY.NAME_RESOLVE`-based replacement (mirroring rsim/oracle-enhanced#2686) measured the same ~0.43 ms/call on the same fixture, confirming the catalog query isn't the bottleneck at ruby-plsql's typical scales. The slow case the original comment was written for (oracle-enhanced#2686 saw 29x on private synonyms in a 1000-object schema) doesn't show up here.
- **"overridden in OCI connection with faster native OCI method"** — that override was removed in `4d1f656` (Feb 2018, "Remove `OCI8#describe_synonym` to follow up #153"), and the preceding commit `1daa6ce` had already emptied the body to just `super`. There is no driver-specific override today.

The method's name and SQL are self-explanatory; removing both lines without a replacement keeps the file accurate.

## Test plan

- [ ] CI green — pure comment removal, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)