### PR TITLE
Add optional SQL logging spec helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pkg
 log
 tmp
 sqlnet.log
+debug.log
 Gemfile.lock
 *.zip
 .idea

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 group :test, :development do
   gem "rake", ">= 10.0"
   gem "rspec", "~> 3.1"
+  gem "logger"
 
   unless ENV["NO_ACTIVERECORD"]
     gem "activerecord", github: "rails/rails", branch: "main"

--- a/spec/support/sql_logger.rb
+++ b/spec/support/sql_logger.rb
@@ -1,0 +1,35 @@
+# Enable with: PLSQL_DEBUG_LOG=debug.log bundle exec rspec
+# Logger args mirror activerecord-oracle_enhanced-adapter's spec logger
+# (shift_age, shift_size) so debug.log behaves the same way.
+if (log_path = ENV["PLSQL_DEBUG_LOG"]) && !log_path.empty?
+  require "logger"
+
+  PLSQL_DEBUG_LOGGER = Logger.new(log_path, 0, 100 * 1024 * 1024)
+  PLSQL_DEBUG_LOGGER.formatter = ->(_sev, time, _prog, msg) {
+    "#{time.iso8601(6)}  #{msg}\n"
+  }
+
+  module PLSQLSQLLogger
+    def exec(sql, *bindvars)
+      PLSQL_DEBUG_LOGGER.info("EXEC   #{sql.strip}#{bindvars.empty? ? '' : "  BINDS=#{bindvars.inspect}"}")
+      super
+    end
+
+    def cursor_from_query(sql, bindvars = [], options = {})
+      PLSQL_DEBUG_LOGGER.info("QUERY  #{sql.strip}#{bindvars.empty? ? '' : "  BINDS=#{bindvars.inspect}"}")
+      super
+    end
+
+    def parse(sql)
+      PLSQL_DEBUG_LOGGER.info("PARSE  #{sql.strip}")
+      super
+    end
+  end
+
+  PLSQL::OCIConnection.prepend(PLSQLSQLLogger)  if defined?(PLSQL::OCIConnection)
+  PLSQL::JDBCConnection.prepend(PLSQLSQLLogger) if defined?(PLSQL::JDBCConnection)
+
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.logger = PLSQL_DEBUG_LOGGER
+  end
+end

--- a/spec/support/sql_logger.rb
+++ b/spec/support/sql_logger.rb
@@ -1,35 +1,33 @@
-# Enable with: PLSQL_DEBUG_LOG=debug.log bundle exec rspec
+# Always write SQL executed during the spec run to debug.log.
 # Logger args mirror activerecord-oracle_enhanced-adapter's spec logger
 # (shift_age, shift_size) so debug.log behaves the same way.
-if (log_path = ENV["PLSQL_DEBUG_LOG"]) && !log_path.empty?
-  require "logger"
+require "logger"
 
-  PLSQL_DEBUG_LOGGER = Logger.new(log_path, 0, 100 * 1024 * 1024)
-  PLSQL_DEBUG_LOGGER.formatter = ->(_sev, time, _prog, msg) {
-    "#{time.iso8601(6)}  #{msg}\n"
-  }
+PLSQL_DEBUG_LOGGER = Logger.new("debug.log", 0, 100 * 1024 * 1024)
+PLSQL_DEBUG_LOGGER.formatter = ->(_sev, time, _prog, msg) {
+  "#{time.iso8601(6)}  #{msg}\n"
+}
 
-  module PLSQLSQLLogger
-    def exec(sql, *bindvars)
-      PLSQL_DEBUG_LOGGER.info("EXEC   #{sql.strip}#{bindvars.empty? ? '' : "  BINDS=#{bindvars.inspect}"}")
-      super
-    end
-
-    def cursor_from_query(sql, bindvars = [], options = {})
-      PLSQL_DEBUG_LOGGER.info("QUERY  #{sql.strip}#{bindvars.empty? ? '' : "  BINDS=#{bindvars.inspect}"}")
-      super
-    end
-
-    def parse(sql)
-      PLSQL_DEBUG_LOGGER.info("PARSE  #{sql.strip}")
-      super
-    end
+module PLSQLSQLLogger
+  def exec(sql, *bindvars)
+    PLSQL_DEBUG_LOGGER.info("EXEC   #{sql.strip}#{bindvars.empty? ? '' : "  BINDS=#{bindvars.inspect}"}")
+    super
   end
 
-  PLSQL::OCIConnection.prepend(PLSQLSQLLogger)  if defined?(PLSQL::OCIConnection)
-  PLSQL::JDBCConnection.prepend(PLSQLSQLLogger) if defined?(PLSQL::JDBCConnection)
-
-  if defined?(ActiveRecord::Base)
-    ActiveRecord::Base.logger = PLSQL_DEBUG_LOGGER
+  def cursor_from_query(sql, bindvars = [], options = {})
+    PLSQL_DEBUG_LOGGER.info("QUERY  #{sql.strip}#{bindvars.empty? ? '' : "  BINDS=#{bindvars.inspect}"}")
+    super
   end
+
+  def parse(sql)
+    PLSQL_DEBUG_LOGGER.info("PARSE  #{sql.strip}")
+    super
+  end
+end
+
+PLSQL::OCIConnection.prepend(PLSQLSQLLogger)  if defined?(PLSQL::OCIConnection)
+PLSQL::JDBCConnection.prepend(PLSQLSQLLogger) if defined?(PLSQL::JDBCConnection)
+
+if defined?(ActiveRecord::Base)
+  ActiveRecord::Base.logger = PLSQL_DEBUG_LOGGER
 end


### PR DESCRIPTION
## Summary
- Add `spec/support/sql_logger.rb`: prepend a logging module onto `PLSQL::OCIConnection` and `PLSQL::JDBCConnection` (`exec`, `cursor_from_query`, `parse`) and route `ActiveRecord::Base.logger` to the same `Logger`. Every SQL statement issued during a spec run is written to `debug.log` in the working directory.
- Logger arguments `("debug.log", 0, 100 * 1024 * 1024)` mirror those used in `activerecord-oracle_enhanced-adapter`'s spec helper, so `debug.log` rotates the same way.
- Add `debug.log` to `.gitignore` (matching the oracle_enhanced repo's `.gitignore` entry).
- Add `gem "logger"` to the `Gemfile` because `logger` became a bundled gem in Ruby 3.5; without this declaration, `NO_ACTIVERECORD=1` runs would lose access to it (today it is pulled in transitively only via `activerecord`).

## Test plan
- [ ] `bundle exec rspec spec/plsql/sequence_spec.rb` — passes; `debug.log` is created and contains `EXEC` / `QUERY` / `PARSE` lines for the sequence DDL and `SELECT seq.NEXTVAL FROM dual` queries.
- [ ] `bundle exec rspec spec/plsql/schema_spec.rb` — `debug.log` interleaves PL/SQL-side and oracle_enhanced adapter SQL.
- [ ] `NO_ACTIVERECORD=1 bundle exec rspec spec/plsql/sequence_spec.rb` — works on Ruby 3.5+ thanks to the explicit `gem "logger"`; only PL/SQL-side SQL is logged.
- [ ] `git status` after a run shows `debug.log` ignored.