### PR TITLE
Remove unused juwelier development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,27 +10,6 @@ end
 
 require "rake"
 
-begin
-  require "juwelier"
-  Juwelier::Tasks.new do |gem|
-    gem.name = "ruby-plsql"
-    gem.summary = "Ruby API for calling Oracle PL/SQL procedures."
-    gem.description = <<-EOS
-  ruby-plsql gem provides simple Ruby API for calling Oracle PL/SQL procedures.
-  It could be used both for accessing Oracle PL/SQL API procedures in legacy applications
-  as well as it could be used to create PL/SQL unit tests using Ruby testing libraries.
-  EOS
-    gem.email = "raimonds.simanovskis@gmail.com"
-    gem.homepage = "http://github.com/rsim/ruby-plsql"
-    gem.license = "MIT".freeze
-    gem.authors = ["Raimonds Simanovskis"]
-    gem.extra_rdoc_files = ["README.md"]
-  end
-  Juwelier::RubygemsDotOrgTasks.new
-rescue LoadError
-  # juwelier not installed
-end
-
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 

--- a/gemfiles/Gemfile.activerecord-5.0
+++ b/gemfiles/Gemfile.activerecord-5.0
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-5.1
+++ b/gemfiles/Gemfile.activerecord-5.1
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-5.2
+++ b/gemfiles/Gemfile.activerecord-5.2
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-6.0
+++ b/gemfiles/Gemfile.activerecord-6.0
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-6.1
+++ b/gemfiles/Gemfile.activerecord-6.1
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-7.0
+++ b/gemfiles/Gemfile.activerecord-7.0
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-7.1
+++ b/gemfiles/Gemfile.activerecord-7.1
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-7.2
+++ b/gemfiles/Gemfile.activerecord-7.2
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-8.0
+++ b/gemfiles/Gemfile.activerecord-8.0
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 

--- a/gemfiles/Gemfile.activerecord-8.1
+++ b/gemfiles/Gemfile.activerecord-8.1
@@ -1,7 +1,6 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'juwelier', '~> 2.0'
   gem 'rspec_junit_formatter'
 end
 


### PR DESCRIPTION
## Summary
- The gemspec is now hand-maintained as `ruby-plsql.gemspec`, so the `Juwelier::Tasks` block in the `Rakefile` (already guarded by `rescue LoadError` because the top-level `Gemfile` long ago dropped juwelier) is dead code.
- Each `gemfiles/Gemfile.activerecord-*` variant still listed `gem 'juwelier', '~> 2.0'` in `:development` — pointless for CI and misleading to contributors.
- Drops both: 11 files changed, 31 deletions.
- `History.txt`'s "Migrate from jeweler to juwelier" line is intentionally kept as a historical changelog entry.

## Test plan
- [ ] `bundle install` at the repo root resolves cleanly.
- [ ] `BUNDLE_GEMFILE=gemfiles/Gemfile.activerecord-8.1 bundle install` (and a spot-check of one or two other variants) resolves cleanly.
- [ ] `bundle exec rake -T` lists the rspec/rdoc tasks without error (no juwelier-only tasks were relied on).
- [ ] CI matrix in `.github/workflows/test_gemfiles.yml` is green across every gemfile variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)