### PR TITLE
Validate RSpec 4 compatibility via disable_monkey_patching!

### DIFF
--- a/spec/plsql/connection_spec.rb
+++ b/spec/plsql/connection_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Connection" do
+RSpec.describe "Connection" do
 
   before(:all) do
     @raw_conn = get_connection

--- a/spec/plsql/package_spec.rb
+++ b/spec/plsql/package_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Package" do
+RSpec.describe "Package" do
   before(:all) do
     plsql.connection = get_connection
     plsql.execute <<-SQL
@@ -113,7 +113,7 @@ describe "Package" do
 
 end
 
-describe "Synonym to package" do
+RSpec.describe "Synonym to package" do
 
   before(:all) do
     plsql.connection = get_connection
@@ -151,7 +151,7 @@ describe "Synonym to package" do
 
 end
 
-describe "Public synonym to package" do
+RSpec.describe "Public synonym to package" do
 
   before(:all) do
     plsql.connection = get_connection

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Parameter type mapping /" do
+RSpec.describe "Parameter type mapping /" do
 
   shared_examples "Function with string parameters" do |datatype|
     before(:all) do
@@ -1997,7 +1997,7 @@ describe "Parameter type mapping /" do
 
 end
 
-describe "Synonyms /" do
+RSpec.describe "Synonyms /" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
   end
@@ -2177,7 +2177,7 @@ describe "Synonyms /" do
 
 end
 
-describe "SYS.STANDARD procedures /" do
+RSpec.describe "SYS.STANDARD procedures /" do
 
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
@@ -2210,7 +2210,7 @@ describe "SYS.STANDARD procedures /" do
 
 end
 
-describe "PLS_INTEGER/SIMPLE_INTEGER should be nullable" do
+RSpec.describe "PLS_INTEGER/SIMPLE_INTEGER should be nullable" do
 
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
@@ -2309,7 +2309,7 @@ describe "PLS_INTEGER/SIMPLE_INTEGER should be nullable" do
 
 end
 
-describe "#get_argument_metadata" do
+RSpec.describe "#get_argument_metadata" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
   end
@@ -2363,7 +2363,7 @@ describe "#get_argument_metadata" do
   end
 end
 
-describe "case-insensitive params" do
+RSpec.describe "case-insensitive params" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.execute <<-SQL
@@ -2387,7 +2387,7 @@ describe "case-insensitive params" do
   end
 end
 
-describe "Procedure with %ROWTYPE parameter on table that has hidden columns" do
+RSpec.describe "Procedure with %ROWTYPE parameter on table that has hidden columns" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.execute "DROP PACKAGE test_hidden_cols_pkg" rescue nil
@@ -2428,7 +2428,7 @@ describe "Procedure with %ROWTYPE parameter on table that has hidden columns" do
   end
 end
 
-describe "Function with TIMESTAMP columns in %ROWTYPE" do
+RSpec.describe "Function with TIMESTAMP columns in %ROWTYPE" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.execute "DROP FUNCTION test_timestamp_fn" rescue nil
@@ -2466,7 +2466,7 @@ describe "Function with TIMESTAMP columns in %ROWTYPE" do
   end
 end
 
-describe "Function with TABLE OF %ROWTYPE parameter defined in package" do
+RSpec.describe "Function with TABLE OF %ROWTYPE parameter defined in package" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.execute "DROP PACKAGE test_rowtype_pkg" rescue nil
@@ -2500,7 +2500,7 @@ describe "Function with TABLE OF %ROWTYPE parameter defined in package" do
   end
 end
 
-describe "Function with TABLE OF RECORD parameter defined in package (workaround for %ROWTYPE)" do
+RSpec.describe "Function with TABLE OF RECORD parameter defined in package (workaround for %ROWTYPE)" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.execute "DROP PACKAGE test_record_pkg" rescue nil
@@ -2532,7 +2532,7 @@ describe "Function with TABLE OF RECORD parameter defined in package (workaround
   end
 end
 
-describe "Function with cross-schema type reference" do
+RSpec.describe "Function with cross-schema type reference" do
   before(:all) do
     primary_user, _ = DATABASE_USERS_AND_PASSWORDS[0]
     second_user, second_password = DATABASE_USERS_AND_PASSWORDS[1]

--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Schema" do
+RSpec.describe "Schema" do
 
   it "should create Schema object" do
     expect(plsql.class).to eq(PLSQL::Schema)
@@ -8,7 +8,7 @@ describe "Schema" do
 
 end
 
-describe "Schema connection" do
+RSpec.describe "Schema connection" do
 
   before(:each) do
     @conn = get_connection
@@ -57,7 +57,7 @@ describe "Schema connection" do
 
 end
 
-describe "Connection with connect!" do
+RSpec.describe "Connection with connect!" do
 
   before(:all) do
     @username, @password = DATABASE_USERS_AND_PASSWORDS[0]
@@ -114,7 +114,7 @@ describe "Connection with connect!" do
 
 end
 
-describe "Named Schema" do
+RSpec.describe "Named Schema" do
   before(:all) do
     plsql.connection = @conn = get_connection
   end
@@ -141,7 +141,7 @@ describe "Named Schema" do
 
 end
 
-describe "Schema commit and rollback" do
+RSpec.describe "Schema commit and rollback" do
   before(:all) do
     plsql.connection = @conn = get_connection
     plsql.connection.autocommit = false
@@ -183,7 +183,7 @@ describe "Schema commit and rollback" do
 
 end
 
-describe "ActiveRecord connection" do
+RSpec.describe "ActiveRecord connection" do
   before(:all) do
     ActiveRecord::Base.establish_connection(CONNECTION_PARAMS)
     class TestBaseModel < ActiveRecord::Base
@@ -274,7 +274,7 @@ describe "ActiveRecord connection" do
 
 end if defined?(ActiveRecord)
 
-describe "DBMS_OUTPUT logging" do
+RSpec.describe "DBMS_OUTPUT logging" do
 
   before(:all) do
     plsql.connection = get_connection

--- a/spec/plsql/sequence_spec.rb
+++ b/spec/plsql/sequence_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Table" do
+RSpec.describe "Table" do
   before(:all) do
     plsql.connection = get_connection
     plsql.connection.autocommit = false

--- a/spec/plsql/sql_statements_spec.rb
+++ b/spec/plsql/sql_statements_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "SQL statements /" do
+RSpec.describe "SQL statements /" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.connection.autocommit = false

--- a/spec/plsql/table_spec.rb
+++ b/spec/plsql/table_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Table" do
+RSpec.describe "Table" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.connection.autocommit = false

--- a/spec/plsql/type_spec.rb
+++ b/spec/plsql/type_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Type" do
+RSpec.describe "Type" do
   before(:all) do
     plsql.connection = get_connection
     plsql.execute "DROP TYPE t_employee" rescue nil

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Package variables /" do
+RSpec.describe "Package variables /" do
 
   describe "String" do
     before(:all) do

--- a/spec/plsql/version_spec.rb
+++ b/spec/plsql/version_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Version" do
+RSpec.describe "Version" do
   it "should return ruby-plsql version" do
     expect(PLSQL::VERSION).to eq(File.read(File.dirname(__FILE__) + "/../../VERSION").chomp)
   end

--- a/spec/plsql/view_spec.rb
+++ b/spec/plsql/view_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "View" do
+RSpec.describe "View" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS
     plsql.connection.autocommit = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -122,6 +122,7 @@ class Hash
 end
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
   config.order = :random
   Kernel.srand config.seed
 end


### PR DESCRIPTION
## Summary
- Enable `config.disable_monkey_patching!` in `spec/spec_helper.rb` to validate RSpec 4 portability under RSpec 3. RSpec 4 is expected to remove the globally-exposed DSL (top-level `describe`/`context`/etc.), equivalent to `config.expose_dsl_globally = false`, which `disable_monkey_patching!` flips along with `obj.should` / `obj.stub`.
- Convert the 29 outermost `describe "..."` calls across `spec/plsql/*.rb` to `RSpec.describe "..."` so each spec file loads with the global DSL disabled. Nested `describe` / `context` / `shared_examples` are unaffected.
- The suite already uses `expect(...).to` and `allow(...).to receive(...)` syntax, so the `expect_with` / `mock_with` portions of `disable_monkey_patching!` are no-ops here.

## Test plan
- [x] `bundle exec rspec spec/plsql/version_spec.rb` — 1 example, 0 failures (proves `spec_helper.rb` loads with the new flag).
- [x] `bundle exec rspec spec --dry-run` — 461 examples, 0 failures (every spec file registers cleanly with the global DSL disabled).
- [ ] `bundle exec rspec spec` against an Oracle DB — pass/fail counts should match `master`. Any new failure that references RSpec internals (`should`, `stub`, exposed DSL) is a real RSpec-4-portability bug to investigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)