### PR TITLE
ci: Pin Bundler to 4.0.6 in RuboCop workflow as workaround for ruby/rubygems#9536

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,6 +10,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      BUNDLER_VERSION: 4.0.6
 
     steps:
     - uses: actions/checkout@v6
@@ -17,6 +19,12 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "4.0"
+    - name: Pin Bundler to 4.0.6 (workaround for ruby/rubygems#9536)
+      run: |
+        gem install bundler -v 4.0.6
+        ruby --version
+        gem --version
+        bundle --version
     - name: Build and run RuboCop
       run: |
         BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary

The `RuboCop` workflow started failing on master at 2026-05-12T01:01 UTC ([run 25706708602](https://github.com/rsim/ruby-plsql/actions/runs/25706708602/job/75478288616)). With Ruby 4.0.4 (Bundler 4.0.11 bundled), `BUNDLE_ONLY=rubocop bundle install` fails to resolve this Gemfile against the multi-gemspec git source `rails/rails` whose top-level gem is in a filtered-out group, aborting with:

```
Could not find compatible versions
```

Bundler 4.0.5 and 4.0.6 succeed; 4.0.7 through 4.0.11 fail. The upstream Bundler regression is tracked in [ruby/rubygems#9536](https://github.com/ruby/rubygems/issues/9536).

Pin Bundler explicitly so the workflow keeps rolling on `ruby-version: "4.0"`:

- set ` BUNDLER_VERSION=4.0.6` at the job level so every `bundle` invocation in the workflow resolves to that version
- `gem install bundler -v 4.0.6` so the version is actually present in the Ruby image (the ruby-builder tarball ships only one Bundler; current 4.0.x tarballs no longer ship 4.0.6)

Once Bundler ships a fix for [ruby/rubygems#9536](https://github.com/ruby/rubygems/issues/9536), drop \`BUNDLER_VERSION\` and the install step.

Mirrors [rsim/oracle-enhanced#2767](https://github.com/rsim/oracle-enhanced/pull/2767).

## Test plan

- [ ] Watch this PR's \`RuboCop\` workflow run and confirm it succeeds.