### PR TITLE
ci: Add ORA_TZFILE workaround to ruby_head workflow

### DIFF
--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -62,6 +62,17 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
+    - name: Force client TZ data to match server (ORA_TZFILE workaround)
+      run: |
+        ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+        SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+        echo "Server TZ file: $SRC"
+        DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+        sudo mkdir -p "$DST_DIR"
+        docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+        sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+        ls -l "$DST_DIR"
+        echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary

The scheduled `ruby_head` workflow has been failing since 2026-05-09 with `OCIError: ORA-01805: possible error in date/time operation` raised from `ocidatetime.c:119` for every DATE/TIMESTAMP fetch:

https://github.com/rsim/ruby-plsql/actions/runs/25586756343

Cause: `gvenzl/oracle-free:latest` now ships Oracle Free 23ai with a newer timezone-data version (`timezlrg_*.dat` under the server `$ORACLE_HOME/oracore/zoneinfo`) than the "latest" `instantclient-basic-linuxx64.zip` download embeds. ruby-oci8 raises ORA-01805 whenever the client tries to materialize a date/time value fetched from a session opened against the newer server.

Copy the server's `timezlrg_*.dat` onto the Instant Client and point `ORA_TZFILE` at it, immediately after the `Create database user` step. The lookup is dynamic so a future bump of the gvenzl image (which ships whatever timezone version is current) continues to work without further edits.

Mirrors [rsim/oracle-enhanced#2764](https://github.com/rsim/oracle-enhanced/pull/2764).

Note: `test.yml`, `test_gemfiles.yml`, `jruby_head.yml`, and `truffleruby.yml` use the same `gvenzl/oracle-free:latest` image and will hit the same failure on their next run. Scoping this PR narrowly to the workflow that has been failing on schedule; happy to expand if preferred.

## Test plan

- [ ] Watch this PR's `ruby_head` workflow run (manual re-dispatch may be needed since it's a scheduled workflow) and confirm the previously-failing `procedure_spec.rb`/`connection_spec.rb`/`variable_spec.rb`/`view_spec.rb`/`table_spec.rb`/`sql_statements_spec.rb` examples pass.