### PR TITLE
ci: Add ORA_TZFILE workaround to remaining gvenzl/oracle-free workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,17 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
+    - name: Force client TZ data to match server (ORA_TZFILE workaround)
+      run: |
+        ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+        SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+        echo "Server TZ file: $SRC"
+        DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+        sudo mkdir -p "$DST_DIR"
+        docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+        sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+        ls -l "$DST_DIR"
+        echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/test_gemfiles.yml
+++ b/.github/workflows/test_gemfiles.yml
@@ -88,6 +88,17 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
+    - name: Force client TZ data to match server (ORA_TZFILE workaround)
+      run: |
+        ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+        SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+        echo "Server TZ file: $SRC"
+        DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+        sudo mkdir -p "$DST_DIR"
+        docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+        sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+        ls -l "$DST_DIR"
+        echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -63,6 +63,17 @@ jobs:
     - name: Create database user
       run: |
         ./ci/setup_accounts.sh
+    - name: Force client TZ data to match server (ORA_TZFILE workaround)
+      run: |
+        ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+        SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+        echo "Server TZ file: $SRC"
+        DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+        sudo mkdir -p "$DST_DIR"
+        docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+        sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+        ls -l "$DST_DIR"
+        echo "ORA_TZFILE=$DST_DIR/$(basename "$SRC")" >> $GITHUB_ENV
     - name: Bundle install
       run: |
         bundle install --jobs 4 --retry 3


### PR DESCRIPTION
## Summary

#291 added the ORA-01805 workaround to `ruby_head.yml`. The same root cause — `gvenzl/oracle-free:latest` shipping a newer `timezlrg_*.dat` than the "latest" Instant Client embeds — affects every other workflow that combines that image with ruby-oci8:

- **`truffleruby.yml`**: failing on schedule since 2026-05-09 with `ORA-01805` from `ocidatetime.c:119 in oci8lib_truffleruby.so` ([run 25710673905](https://github.com/rsim/ruby-plsql/actions/runs/25710673905)).
- **`test.yml`**: not yet run against the updated image (latest run was 2026-05-08, image upgrade landed on 05-09); will fail on the MRI matrix slots (`4.0`, `3.4`, `3.3`) on the next push/PR.
- **`test_gemfiles.yml`**: same situation as `test.yml`.

Apply the same dynamic copy-and-set-`ORA_TZFILE` step immediately after `Create database user`, identical to #291.

`jruby_head.yml` is excluded because it uses the JDBC driver and is not affected (confirmed still green on schedule).

Stacked on top of #291 in spirit (same fix, same root cause) but contains an independent file set, so the two can land in either order.

## Test plan

- [ ] Watch this PR's `test` and `test_gemfiles` workflow runs and confirm they succeed.
- [ ] After merge, watch the scheduled `truffleruby` workflow and confirm it succeeds.