### PR TITLE
Introduce .rspec config and drop RUBYOPT=-w from CI workflows

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 6 1 * *"  # 1st of every month at 6:00 AM UTC
   workflow_dispatch:
 
-env:
-  RUBYOPT: "-w"
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/jruby_head.yml
+++ b/.github/workflows/jruby_head.yml
@@ -72,4 +72,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.github/workflows/ruby_head.yml
+++ b/.github/workflows/ruby_head.yml
@@ -78,4 +78,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,4 +90,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -96,4 +96,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -91,4 +91,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.github/workflows/test_gemfiles.yml
+++ b/.github/workflows/test_gemfiles.yml
@@ -104,4 +104,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -79,4 +79,4 @@ jobs:
         bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: |
-        RUBYOPT=-w bundle exec rspec
+        bundle exec rspec

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--force-color
+--backtrace
+--require spec_helper
+--warnings


### PR DESCRIPTION
## Summary

Mirror the `.rspec` from [rsim/oracle-enhanced](https://github.com/rsim/oracle-enhanced/blob/master/.rspec):

```
--force-color
--backtrace
--require spec_helper
--warnings
```

The `--warnings` flag replaces the per-workflow `RUBYOPT=-w` prefix on `bundle exec rspec`, so the same warning surface is now driven from a single project-level file rather than seven workflow scripts plus one workflow-level env block in `devcontainer.yml`.

- `--force-color` keeps RSpec output colored when piped through CI log capture
- `--backtrace` shows full backtraces on failure
- `--require spec_helper` lets future spec files skip the explicit require (existing `require "spec_helper"` lines remain — they are now redundant but harmless, and cleaning them up is out of scope here)
- `--warnings` is equivalent to `RUBYOPT=-w` for the rspec process

### Files changed

- `.rspec` (new)
- `.github/workflows/test.yml`
- `.github/workflows/test_11g.yml`
- `.github/workflows/test_11g_ojdbc11.yml`
- `.github/workflows/test_gemfiles.yml`
- `.github/workflows/ruby_head.yml`
- `.github/workflows/jruby_head.yml`
- `.github/workflows/truffleruby.yml`
- `.github/workflows/devcontainer.yml` (drops the workflow-level `env: RUBYOPT: "-w"` block; `bundle exec rake spec` picks up `.rspec` via `RSpec::Core::RakeTask`)

Diff stat: 9 files changed, 11 insertions(+), 10 deletions(-)

## Test plan

- [x] `bundle exec rspec spec/plsql/procedure_spec.rb` — 195 examples, 0 failures, 1 pre-existing pending
- [x] `bundle exec rspec spec/plsql/version_spec.rb spec/plsql/sequence_spec.rb` — confirms `.rspec` is picked up locally (ANSI color appears in piped output → `--force-color` active)
- [x] No new Ruby warnings emitted under `--warnings`
- [ ] CI matrix exercises the JRuby / Ruby head / multi-AR-version paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)