### PR TITLE
Move ora_number_to_ruby_number to Connection base class

### DIFF
--- a/lib/plsql/connection.rb
+++ b/lib/plsql/connection.rb
@@ -266,5 +266,12 @@ module PLSQL
         exec "DROP TABLE #{row[0]}"
       end
     end
+
+    private
+
+      def ora_number_to_ruby_number(num)
+        # return BigDecimal instead of Float to avoid rounding errors
+        num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal(num.to_s))
+      end
   end
 end

--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -588,10 +588,5 @@ module PLSQL
       def java_bigdecimal(value)
         value && java.math.BigDecimal.new(value.to_s)
       end
-
-      def ora_number_to_ruby_number(num)
-        # return BigDecimal instead of Float to avoid rounding errors
-        num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal(num.to_s))
-      end
   end
 end

--- a/lib/plsql/oci_connection.rb
+++ b/lib/plsql/oci_connection.rb
@@ -301,11 +301,6 @@ module PLSQL
         end
       end
 
-      def ora_number_to_ruby_number(num)
-        # return BigDecimal instead of Float to avoid rounding errors
-        num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal(num.to_s))
-      end
-
       def ora_date_to_ruby_date(val)
         case val
         when DateTime


### PR DESCRIPTION
## Summary

`ora_number_to_ruby_number` was duplicated **character-for-character** as a private method in both `OCIConnection` and `JDBCConnection`:

```ruby
def ora_number_to_ruby_number(num)
  # return BigDecimal instead of Float to avoid rounding errors
  num == (num_to_i = num.to_i) ? num_to_i : (num.is_a?(BigDecimal) ? num : BigDecimal(num.to_s))
end
```

Pull it up into the `Connection` base class. Both subclasses keep calling it unchanged via inheritance (3 call sites: 1 in `oci_connection.rb`, 2 in `jdbc_connection.rb`). The rule "return BigDecimal instead of Float to avoid rounding errors" now lives in one place.

Diff stat:

```
 lib/plsql/connection.rb      | 7 +++++++
 lib/plsql/jdbc_connection.rb | 5 -----
 lib/plsql/oci_connection.rb  | 5 -----
 3 files changed, 7 insertions(+), 10 deletions(-)
```

Net **-3 LOC**.

## Test plan

- [x] `bundle exec rspec` — 468 examples, 0 failures, 1 pre-existing pending
- [x] `ruby -c` on each of the three modified files passes
- [x] Grep confirms the method is defined exactly once (in `connection.rb`) and call sites remain in the two driver files
- [ ] CI matrix exercises both the OCI (MRI) and JDBC (JRuby) paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)