### PR TITLE
Remove empty result_set_to_ruby_data_type method

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -390,9 +390,6 @@ module PLSQL
       ora_value_to_ruby_value(ora_value)
     end
 
-    def result_set_to_ruby_data_type(column_type, column_type_name)
-    end
-
     def plsql_to_ruby_data_type(metadata)
       data_type, data_length = metadata[:data_type], metadata[:data_length]
       case data_type


### PR DESCRIPTION
## Summary

`JDBCConnection` defined an empty stub:

```ruby
def result_set_to_ruby_data_type(column_type, column_type_name)
end
```

It returned `nil`, had zero call sites anywhere in `lib/` or `spec/`, and no dynamic dispatch construction targets the name. The enclosing class is tagged `# :nodoc:`, so removing the stub does not affect a documented public API surface.

### Verification before deletion

- `grep -rn "result_set_to_ruby_data_type" lib/ spec/` → 1 match (the definition itself)
- `grep -rn "send.*result_set|to_ruby_data_type|public_send.*result|respond_to?.*result_set" lib/ spec/` → no dynamic-dispatch construction would resolve to this name
- README / Usage docs reference `plsql.<procedure>` style APIs, not this internal method
- `class JDBCConnection < Connection # :nodoc:` — opted out of public documentation

### Origin

`git log --all -S "def result_set_to_ruby_data_type" -- lib/plsql/jdbc_connection.rb` shows the method was introduced **empty from day one** in commit `ca4bebf` (2009-11-17), part of the larger "support for cursor return values and output parameters in JRuby / JDBC" change that overhauled `jdbc_connection.rb` (+154 / -113 across 4 files).

The signature `(column_type, column_type_name)` mirrors JDBC's `ResultSetMetaData#getColumnType(i)` / `#getColumnTypeName(i)`, suggesting it was planned as a JDBC-ResultSet counterpart to `plsql_to_ruby_data_type(metadata)` — but the implementation that actually landed took a different route (the `SQL_TYPE_TO_RUBY_CLASS` lookup used by `get_ruby_value_from_result_set`). The stub was orphaned and never called. Across ~16 years and 5 subsequent edits to the method's textual surface, every change has been whitespace-only.

Diff stat: `lib/plsql/jdbc_connection.rb | 3 ---` (-3 lines).

## Test plan

- [x] `bundle exec rspec` — 468 examples, 0 failures, 1 pre-existing pending
- [x] `ruby -c lib/plsql/jdbc_connection.rb` passes
- [x] Grep confirms zero remaining references to the method name
- [ ] CI matrix exercises the JDBC (JRuby) path

🤖 Generated with [Claude Code](https://claude.com/claude-code)