### PR TITLE
Drop redundant require "spec_helper" from spec files

### DIFF
--- a/spec/plsql/connection_spec.rb
+++ b/spec/plsql/connection_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require "spec_helper"
-
 RSpec.describe "Connection" do
 
   before(:all) do

--- a/spec/plsql/package_spec.rb
+++ b/spec/plsql/package_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "Package" do
   before(:all) do
     plsql.connection = get_connection

--- a/spec/plsql/procedure_spec.rb
+++ b/spec/plsql/procedure_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require "spec_helper"
-
 RSpec.describe "Parameter type mapping /" do
 
   shared_examples "Function with string parameters" do |datatype|

--- a/spec/plsql/schema_spec.rb
+++ b/spec/plsql/schema_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "Schema" do
 
   it "should create Schema object" do

--- a/spec/plsql/sequence_spec.rb
+++ b/spec/plsql/sequence_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "Table" do
   before(:all) do
     plsql.connection = get_connection

--- a/spec/plsql/sql_statements_spec.rb
+++ b/spec/plsql/sql_statements_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "SQL statements /" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS

--- a/spec/plsql/table_spec.rb
+++ b/spec/plsql/table_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "Table" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS

--- a/spec/plsql/type_spec.rb
+++ b/spec/plsql/type_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "Type" do
   before(:all) do
     plsql.connection = get_connection

--- a/spec/plsql/variable_spec.rb
+++ b/spec/plsql/variable_spec.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require "spec_helper"
-
 RSpec.describe "Package variables /" do
 
   describe "String" do

--- a/spec/plsql/version_spec.rb
+++ b/spec/plsql/version_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "Version" do
   it "should return ruby-plsql version" do
     expect(PLSQL::VERSION).to eq(File.read(File.dirname(__FILE__) + "/../../VERSION").chomp)

--- a/spec/plsql/view_spec.rb
+++ b/spec/plsql/view_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "View" do
   before(:all) do
     plsql.connect! CONNECTION_PARAMS


### PR DESCRIPTION
## Summary

The project-level `.rspec` introduced in #294 contains `--require spec_helper`, which makes RSpec auto-load `spec/spec_helper.rb` before any example file. The explicit `require "spec_helper"` at the top of each `spec/plsql/*.rb` is therefore redundant.

Remove the require line plus the immediately-following blank line from all 11 files under `spec/plsql/`:

- connection_spec.rb
- package_spec.rb
- procedure_spec.rb
- schema_spec.rb
- sequence_spec.rb
- sql_statements_spec.rb
- table_spec.rb
- type_spec.rb
- variable_spec.rb
- version_spec.rb
- view_spec.rb

The `# encoding: utf-8` magic comment that appears at the top of three files (connection_spec.rb, procedure_spec.rb, variable_spec.rb) is intentionally left alone — out of scope here.

Diff stat: 11 files changed, 22 deletions(-).

## Test plan

- [x] `bundle exec rspec` — 468 examples, 0 failures, 1 pre-existing pending (the Oracle 9.2 indexed-by-binary-integer skip). Confirms `--require spec_helper` from `.rspec` continues to load the helper before each example file.
- [x] Grep confirms zero remaining `require "spec_helper"` lines under `spec/plsql/`
- [ ] CI matrix exercises all Ruby / AR / driver combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)