### PR TITLE
Replace `if not value.nil?` with `unless value.nil?`

### DIFF
--- a/lib/plsql/procedure_call.rb
+++ b/lib/plsql/procedure_call.rb
@@ -243,8 +243,8 @@ module PLSQL
         when "UNDEFINED", "XMLTYPE", "OPAQUE/XMLTYPE"
           if xmltype_argument?(argument_metadata)
             @declare_sql << "l_#{argument} XMLTYPE;\n"
-            @assignment_sql << "l_#{argument} := XMLTYPE(:#{argument});\n" if not value.nil?
-            @bind_values[argument] = value if not value.nil?
+            @assignment_sql << "l_#{argument} := XMLTYPE(:#{argument});\n" unless value.nil?
+            @bind_values[argument] = value unless value.nil?
             @bind_metadata[argument] = argument_metadata.merge(data_type: "CLOB")
             "l_#{argument}"
           end


### PR DESCRIPTION
## Summary

In `add_argument`'s XMLTYPE branch, two adjacent trailing modifiers used the awkward double-negation form:

```ruby
@assignment_sql << "l_#{argument} := XMLTYPE(:#{argument});\n" if not value.nil?
@bind_values[argument] = value if not value.nil?
```

Replace each with `unless value.nil?` — same semantics, idiomatic Ruby, same line count.

```ruby
@assignment_sql << "l_#{argument} := XMLTYPE(:#{argument});\n" unless value.nil?
@bind_values[argument] = value unless value.nil?
```

Scope is intentionally narrow. The remaining `if !x.empty?` at `procedure_call.rb:105` pairs with an `elsif !x.empty?` at line 107 where `unless` cannot be substituted, so it is left alone for symmetry.

Diff stat: `lib/plsql/procedure_call.rb | 4 ++--` (+2 / -2, two single-line changes).

## Test plan

- [x] `bundle exec rspec` — 468 examples, 0 failures, 1 pre-existing pending
- [x] Grep confirms no remaining `if not ` constructs in `lib/plsql/procedure_call.rb` outside of a code comment that legitimately mentions "if not overloaded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)