### PR TITLE
Drop redundant .to_s inside string interpolation

### DIFF
--- a/lib/plsql/jdbc_connection.rb
+++ b/lib/plsql/jdbc_connection.rb
@@ -189,7 +189,7 @@ module PLSQL
 
         def bind_param_index(key)
           return key if key.kind_of? Integer
-          key = ":#{key.to_s}" unless key.to_s =~ /^:/
+          key = ":#{key}" unless key.to_s =~ /^:/
           @params.index(key) + 1
         end
     end


### PR DESCRIPTION
## Summary

In `CallableStatement#bind_param_index` the leading-colon normalization wrote:

```ruby
key = ":#{key.to_s}" unless key.to_s =~ /^:/
```

Ruby's string interpolation already calls `to_s` on the embedded expression, so the explicit `.to_s` inside `"#{...}"` is redundant.

```ruby
key = ":#{key}" unless key.to_s =~ /^:/
```

The `key.to_s =~ /^:/` on the right-hand side is intentionally kept — it is **outside** the interpolation and exists to ensure the regex match receives a String regardless of whether `key` arrives as a Symbol or String. Out of scope here.

Diff stat: `lib/plsql/jdbc_connection.rb | 2 +-` (1 line modified).

## Test plan

- [x] `bundle exec rspec` — 468 examples, 0 failures, 1 pre-existing pending
- [ ] CI matrix exercises the JDBC (JRuby) path where this code lives

🤖 Generated with [Claude Code](https://claude.com/claude-code)