### PR TITLE
Apply ORA_TZFILE workaround to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
   "features": {
     "ghcr.io/rails/devcontainer/features/ruby:2": {
       "version": "4.0.3"
-    }
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -22,4 +22,21 @@ fi
 
 ci/setup_accounts.sh
 
+# Force client TZ data to match server (ORA_TZFILE workaround).
+# Mirrors the CI workaround added in rsim/ruby-plsql#292: gvenzl/oracle-free
+# ships a newer timezone-data version than the "latest" Instant Client embeds,
+# so ruby-oci8 raises ORA-01805 for DATE/TIMESTAMP fetches unless the client
+# uses the server's timezlrg_*.dat. The Docker CLI and socket are provided by
+# the docker-outside-of-docker devcontainer feature.
+ORACLE_CONTAINER=$(docker ps --filter "ancestor=gvenzl/oracle-free" -q)
+SRC=$(docker exec "$ORACLE_CONTAINER" bash -c 'ls $ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat 2>/dev/null | head -1')
+echo "Server TZ file: $SRC"
+DST_DIR="$ORACLE_HOME/oracore/zoneinfo"
+sudo mkdir -p "$DST_DIR"
+docker cp "$ORACLE_CONTAINER":"$SRC" /tmp/_server_tzfile.dat
+sudo mv /tmp/_server_tzfile.dat "$DST_DIR/$(basename "$SRC")"
+ls -l "$DST_DIR"
+echo "export ORA_TZFILE=$DST_DIR/$(basename "$SRC")" | sudo tee /etc/profile.d/ora_tzfile.sh > /dev/null
+sudo chmod +x /etc/profile.d/ora_tzfile.sh
+
 echo "Dev container setup complete. You are ready to start developing ruby-plsql!"


### PR DESCRIPTION
## Summary

- #292 applied the `ORA-01805` workaround to the remaining `gvenzl/oracle-free` CI workflows. The same root cause -- the server image shipping a newer timezone-data version than the "latest" Instant Client embeds -- also affects the dev container, which pairs `gvenzl/oracle-free:latest` with the Instant Client installed via the app `Dockerfile` and reaches it through ruby-oci8.
- Mirror the workflow step in `.devcontainer/postCreateCommand.sh` right after `ci/setup_accounts.sh`: locate the running Oracle container, copy its `timezlrg_*.dat` onto the Instant Client's `oracore/zoneinfo`, and persist `ORA_TZFILE` via `/etc/profile.d/ora_tzfile.sh` so every login shell (and the rspec runs they launch) picks it up.
- Add `ghcr.io/devcontainers/features/docker-outside-of-docker` alongside the existing Ruby feature in `.devcontainer/devcontainer.json` to provide the Docker CLI and host socket the workaround needs for `docker exec` / `docker cp`.

The lookup is dynamic, so a future gvenzl image bump continues to work without further edits.

## Test plan

- [ ] Rebuild the dev container ("Dev Containers: Rebuild Container") and confirm `postCreateCommand.sh` finishes with `Dev container setup complete.` and a non-empty `ORA_TZFILE` line in `/etc/profile.d/ora_tzfile.sh`.
- [ ] Open a fresh terminal in the rebuilt container and verify `echo \$ORA_TZFILE` prints the copied `timezlrg_*.dat` under `\$ORACLE_HOME/oracore/zoneinfo`, and that the file exists.
- [ ] Run the spec suite (per the project's documented rspec command) and confirm DATE/TIMESTAMP specs pass without `ORA-01805`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)