### PR TITLE
Use Ruby 4.0.4 in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "workspaceFolder": "/workspaces/ruby-plsql",
   "features": {
     "ghcr.io/rails/devcontainer/features/ruby:2": {
-      "version": "4.0.3"
+      "version": "4.0.4"
     }
   },
   "customizations": {


### PR DESCRIPTION
## Summary

- Ruby 4.0.4 became available in the Rails devcontainer Ruby feature once rails/devcontainer#126 was merged.
- Bump the pinned version in `.devcontainer/devcontainer.json` from `4.0.3` to `4.0.4` so a fresh devcontainer build installs the latest 4.0.x patch.
- No CI changes are required: workflow files that target a specific release pin `ruby-version: '4.0'`, which resolves to the latest 4.0.x patch automatically.

## Test plan

- [ ] Rebuild the dev container ("Dev Containers: Rebuild Container") and confirm `ruby -v` reports `ruby 4.0.4`.
- [ ] Run the spec suite (per the project's documented rspec command) inside the rebuilt container and confirm no regressions versus 4.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)