### PR TITLE
Align dev container Instant Client TZ data with Oracle server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
       ]
     }
   },
-  "initializeCommand": "docker pull gvenzl/oracle-free:latest",
+  "initializeCommand": "bash .devcontainer/initializeCommand.sh",
   "postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
   "remoteEnv": {
     "DATABASE_NAME": "FREEPDB1",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ../..:/workspaces:cached
+      - ./tzdata:/opt/tzdata:ro
     command: sleep infinity
     network_mode: service:oracle
 

--- a/.devcontainer/initializeCommand.sh
+++ b/.devcontainer/initializeCommand.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+IMAGE=gvenzl/oracle-free:latest
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+OUT_DIR="$SCRIPT_DIR/tzdata"
+
+docker pull "$IMAGE"
+
+mkdir -p "$OUT_DIR"
+rm -f "$OUT_DIR"/timezlrg_*.dat "$OUT_DIR"/timezdif_*.dat
+
+docker run --rm --entrypoint sh \
+  -v "$OUT_DIR:/out" \
+  "$IMAGE" \
+  -c 'cp "$ORACLE_HOME"/oracore/zoneinfo/timezlrg_*.dat /out/ && chmod a+r /out/*.dat'
+
+ls -1 "$OUT_DIR"

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -5,6 +5,18 @@ set -e
 gem update --system
 bundle install
 
+# Match Instant Client TZ data to the Oracle server's to avoid ORA-01805.
+# The file is extracted from the gvenzl image into .devcontainer/tzdata/ by
+# initializeCommand.sh and bind-mounted read-only at /opt/tzdata.
+TZ_FILE=$(ls /opt/tzdata/timezlrg_*.dat 2>/dev/null | head -1)
+if [ -n "$TZ_FILE" ]; then
+  echo "Using $TZ_FILE for Instant Client TZ data."
+  export ORA_TZFILE="$TZ_FILE"
+  echo "export ORA_TZFILE=$TZ_FILE" | sudo tee /etc/profile.d/ora-tzfile.sh > /dev/null
+else
+  echo "Warning: no timezlrg_*.dat found under /opt/tzdata; skipping ORA_TZFILE setup." >&2
+fi
+
 echo "Waiting for Oracle to be ready..."
 oracle_ready=false
 for i in $(seq 1 30); do

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Gemfile.lock
 *.zip
 .idea
 spec/support/custom_config.rb
+.devcontainer/tzdata/


### PR DESCRIPTION
## Summary

Apply the workaround from #292 to the dev container. CI fixed `ORA-01805: possible error in date/time operation` by copying the running Oracle server's `timezlrg_*.dat` into the Instant Client's `oracore/zoneinfo/` and pointing `ORA_TZFILE` at it. The dev container combines `gvenzl/oracle-free:latest` with the Instant Client installed via the app `Dockerfile` and is exposed to the same drift, so it benefits from the same fix.

#301 ported the workaround by adding the `docker-outside-of-docker` feature and doing the copy from inside the dev container via `docker exec` / `docker cp`. That PR was closed unmerged because the feature fails to install on Dev Containers 0.459.0 against `mcr.microsoft.com/devcontainers/base:trixie` — Debian trixie removed `moby-cli`:

```
(!) The 'moby' option is not supported on Debian 'trixie' because 'moby-cli'
    and related system packages have been removed from that distribution.
ERROR: Feature "Docker (docker-outside-of-docker)" failed to install!
```

This PR moves the copy to the host, where Docker is already available. Mirrors rsim/oracle-enhanced#2799.

## Changes

- `.devcontainer/initializeCommand.sh` (new) — pull `gvenzl/oracle-free:latest`, then extract `$ORACLE_HOME/oracore/zoneinfo/timezlrg_*.dat` from an ephemeral container into `.devcontainer/tzdata/` on the host. No DB start, no readiness wait — the file ships in the image.
- `.devcontainer/devcontainer.json` — `initializeCommand` now runs the new script (it previously did the inline `docker pull`). No `docker-outside-of-docker` feature.
- `.devcontainer/docker-compose.yml` — bind-mount `.devcontainer/tzdata` read-only at `/opt/tzdata` inside the `app` service.
- `.devcontainer/postCreateCommand.sh` — set `ORA_TZFILE` from `/opt/tzdata/timezlrg_*.dat` and persist it via `/etc/profile.d/ora-tzfile.sh` so interactive shells and `bundle exec` runs pick it up.
- `.gitignore` — ignore `.devcontainer/tzdata/`.

No `docker-outside-of-docker` feature, no `/var/run/docker.sock` bind, and no network access during the dev container build.

## Lifecycle

Matches #292 — the step is unconditional and becomes a near-zero-cost no-op once the Instant Client and the gvenzl image realign on a single TZ data version. Safe to remove together with the CI counterpart at that point.

## Test plan

- [ ] Rebuild the dev container; `initializeCommand` logs the pulled image and the extracted `timezlrg_*.dat` filename.
- [ ] `postCreateCommand` logs "Using /opt/tzdata/timezlrg_*.dat for Instant Client TZ data."
- [ ] In a fresh terminal inside the rebuilt container, `echo \$ORA_TZFILE` resolves to the persisted path.
- [ ] `bundle exec rake spec` passes without `ORA-01805` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)