### PR TITLE
Fail the devcontainer CI job when rake spec fails

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -18,6 +18,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
+            set -e
             uname -a
             lsb_release -a
             ruby --version


### PR DESCRIPTION
## Summary

`.github/workflows/devcontainer.yml`'s `runCmd` is a multi-line bash script with no `set -e`, so a non-zero exit from `bundle exec rake spec` does not propagate. The script keeps running, executes `bundle exec rubocop`, and the script's exit code becomes RuboCop's exit code. As long as RuboCop is clean, GitHub Actions marks the job green even when rspec is red.

Add `set -e` so the first non-zero exit aborts the script and surfaces through `devcontainers/ci` as a job failure. Mirrors rsim/oracle-enhanced#2801.

## Notes

- Independent of #303 (which fixes the underlying ORA-01805 source). With this in place, once #303 lands, the next `devcontainer` workflow dispatch on master will correctly report green; before #303, it would correctly report red.
- Scope kept intentionally minimal: one `set -e` line. `-u` risks tripping on unset-but-harmless variables and the immediate bug is just exit-code propagation.

## Test plan

- [ ] After this merges, manually dispatch the `devcontainer` workflow on master (still without #303) and confirm the job goes red on the ORA-01805 failures.
- [ ] After #303 also lands, manually dispatch again and confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)