### PR TITLE
ci: Revert Bundler 4.0.6 pin and use rubygems: latest

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,8 +10,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      BUNDLER_VERSION: 4.0.6
 
     steps:
     - uses: actions/checkout@v6
@@ -19,12 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "4.0"
-    - name: Pin Bundler to 4.0.6 (workaround for ruby/rubygems#9536)
-      run: |
-        gem install bundler -v 4.0.6
-        ruby --version
-        gem --version
-        bundle --version
+        rubygems: latest
     - name: Build and run RuboCop
       run: |
         BUNDLE_ONLY=rubocop bundle install --jobs 4 --retry 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        rubygems: latest
     - name: Create symbolic link for libaio library compatibility
       run: |
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -56,6 +56,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        rubygems: latest
     - name: Create symbolic link for libaio library compatibility
       run: |
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -52,6 +52,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        rubygems: latest
     - name: Create symbolic link for libaio library compatibility
       run: |
         sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1


### PR DESCRIPTION
## Summary

- Bundler 4.0.12 [was released on 2026-05-20](https://blog.rubygems.org/2026/05/20/4.0.12-released.html) and includes [ruby/rubygems#9544](https://github.com/rubygems/rubygems/pull/9544), which fixes the multi-gemspec git source resolver regression tracked in [ruby/rubygems#9536](https://github.com/rubygems/rubygems/issues/9536) — the regression PR #290 worked around by pinning Bundler to 4.0.6 in the RuboCop workflow.
- Revert that pin: drop the `BUNDLER_VERSION: 4.0.6` env and the "Pin Bundler to 4.0.6" step from `.github/workflows/rubocop.yml`.
- Add `rubygems: latest` to the modern-CRuby workflows (`rubocop.yml`, `test.yml`, `test_11g.yml`, `test_11g_ojdbc11.yml`), matching the pattern already used in `release.yml`, so CI actually picks up Bundler 4.0.12 instead of whatever ships in the `ruby/setup-ruby@v1` tarball.

### Scope notes

- `ruby_head.yml`, `jruby_head.yml`: untouched — per [setup-ruby docs](https://github.com/ruby/setup-ruby), "Ruby head/master builds will not be updated" by `rubygems: latest`.
- `truffleruby.yml`: untouched — setup-ruby would attempt `gem update --system` on TruffleRuby, which is not reliably supported there.
- `test_gemfiles.yml`: untouched — its matrix targets Ruby 2.4 through 3.3, none of which support RubyGems 4.x.
- JRuby matrix entries in `test.yml` / `test_11g.yml` / `test_11g_ojdbc11.yml`: covered — setup-ruby explicitly handles JRuby with `gem update --system` for `rubygems: latest`.

## Test plan

- [ ] `RuboCop` workflow run completes green; the `Pin Bundler` step is gone and `Set up Ruby 4.0` logs Bundler 4.0.12.
- [ ] `test` workflow run completes green for all matrix entries (`4.0`, `3.4`, `3.3`, `jruby-10.1.0.0`).
- [ ] `test_11g` and `test_11g_ojdbc11` workflows run green.
- [ ] No regression in scheduled workflows (`ruby_head`, `jruby_head`, `truffleruby`) that were intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)