### PR TITLE
Document GitHub Codespaces support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspaces/ruby-plsql",
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
   "features": {
     "ghcr.io/rails/devcontainer/features/ruby:2": {
       "version": "4.0.4"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,35 @@ complete development environment with Oracle Database and all required
 dependencies pre-configured. It supports both x64 and ARM64 hosts, and
 is the recommended way to work on ruby-plsql.
 
+### GitHub Codespaces
+
+You can also work on ruby-plsql without installing Docker or VS Code
+by launching a [GitHub Codespace](https://github.com/features/codespaces),
+which uses the same devcontainer configuration:
+
+1. On the repository page on GitHub, click **Code → Codespaces → Create
+   codespace on master** (or on your fork's topic branch).
+2. Pick a machine type with **at least 4 cores and 8 GB RAM** — Oracle
+   Database Free will not run reliably on the 2-core / 4 GB default.
+   The Codespaces "Create" picker honours the `hostRequirements` declared
+   in `.devcontainer/devcontainer.json`, so 4-core / 8 GB is the default
+   suggestion.
+3. Wait for the Codespace to finish building. The same
+   `initializeCommand` and `postCreateCommand` scripts run as for local
+   Dev Containers: the Oracle server's timezone file is extracted,
+   Oracle Free starts, `ORA_TZFILE` is pointed at the matching file to
+   avoid `ORA-01805`, and `ci/setup_accounts.sh` provisions the `hr`
+   and `arunit` users.
+4. Once setup completes, run the suite the same way as locally:
+
+   ```sh
+   bundle exec rake spec
+   ```
+
+The first-time build takes several minutes (Oracle image pull +
+Instant Client setup + `bundle install`). Subsequent starts of the
+same Codespace are much faster.
+
 ### Prerequisites
 
 - [Docker](https://www.docker.com/get-started) installed and running


### PR DESCRIPTION
## Summary

The repository's existing devcontainer already runs on
[GitHub Codespaces](https://github.com/features/codespaces), but two
small improvements make the experience smoother:

- **`.devcontainer/devcontainer.json`**: declare `hostRequirements`
  (4 cpu / 8 GB RAM / 32 GB storage) so the Codespaces "Create
  codespace" picker defaults to a machine large enough to run Oracle
  Database Free. The default 2 cpu / 4 GB machine is too small to start
  Oracle reliably. `hostRequirements` is ignored by local Dev
  Containers, so this is a Codespaces-only nudge.
- **`CONTRIBUTING.md`**: add a "GitHub Codespaces" subsection under the
  existing "Development with devcontainer" section, describing the
  one-click flow and the machine-size requirement.

No source, CI, or other `.devcontainer/` files are touched.

Mirrors rsim/oracle-enhanced#2807.

## Test plan

- [ ] Open a Codespace on this branch and confirm the machine-type
      picker defaults to a 4-core / 8 GB option.
- [ ] Confirm the Codespace finishes building, `postCreateCommand`
      prints "Dev container setup complete. You are ready to start
      developing ruby-plsql!", and `bundle exec rake spec` runs against
      the in-Codespace Oracle Free.
- [ ] Open the same branch in VS Code Dev Containers locally and
      confirm the container still builds (`hostRequirements` is
      ignored, so behavior should be identical).
- [ ] View the rendered `CONTRIBUTING.md` on GitHub to confirm the new
      subsection renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)