### PR TITLE
Raise dependabot open-pull-requests-limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Raise `open-pull-requests-limit` for the `github-actions` ecosystem from the default of 5 to 10.
- Editing `.github/dependabot.yml` also nudges Dependabot to re-evaluate the manifest on `master`, which is useful because no Dependabot PR has landed since #272 (2026-04-14) even though new major versions of common actions (e.g. `actions/checkout@v7`) have been released in the meantime.

## Background
oracle-enhanced received the equivalent `actions/checkout` v6 → v7 Dependabot PR (rsim/oracle-enhanced#2815, merged 2026-06-20), but the same bump has not appeared here. The most likely cause is that this repo's Dependabot job is stalled; touching the manifest is the simplest way for a non-admin collaborator to trigger a re-evaluation.

## Test plan
- [ ] After merge, watch for new Dependabot PRs against `master` (`gh pr list --repo rsim/ruby-plsql --author "app/dependabot" --state open`).
- [ ] In particular, confirm that an `actions/checkout` v6 → v7 PR is opened within a few minutes / hours.
- [ ] If nothing appears, the Dependabot job itself is likely broken and an admin will need to inspect Insights → Dependency graph → Dependabot.