### PR TITLE
Bump JRuby to 10.1.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-10.1.0.0'
+          ruby-version: 'jruby-10.1.1.0'
           rubygems: latest
       - name: Build gem
         run: gem build ruby-plsql.gemspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.0.0',
+          'jruby-10.1.1.0',
         ]
     env:
       NLS_LANG: AMERICAN_AMERICA.AL32UTF8

--- a/.github/workflows/test_11g.yml
+++ b/.github/workflows/test_11g.yml
@@ -19,7 +19,7 @@ jobs:
           '4.0',
           '3.4',
           '3.3',
-          'jruby-10.1.0.0',
+          'jruby-10.1.1.0',
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_21

--- a/.github/workflows/test_11g_ojdbc11.yml
+++ b/.github/workflows/test_11g_ojdbc11.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby: [
-          'jruby-10.1.0.0'
+          'jruby-10.1.1.0'
         ]
     env:
       ORACLE_HOME: /opt/oracle/instantclient_21_21

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 group :development do
   gem "rspec_junit_formatter"
   gem "rdoc"
+
+  platforms :jruby do
+    gem "rbs", ">= 4.1.0.pre.2" # Use the java-platform gem so JRuby does not build the C extension
+  end
 end
 
 group :rubocop do

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ruby-plsql gem provides simple Ruby API for calling Oracle PL/SQL procedures. It
 
 NUMBER, BINARY_INTEGER, PLS_INTEGER, NATURAL, NATURALN, POSITIVE, POSITIVEN, SIGNTYPE, SIMPLE_INTEGER, VARCHAR, VARCHAR2, NVARCHAR2, CHAR, NCHAR, DATE, TIMESTAMP, CLOB, BLOB, BOOLEAN, PL/SQL RECORD, TABLE, VARRAY, OBJECT and CURSOR types are supported for input and output parameters and return values of PL/SQL procedures and functions.
 
-ruby-plsql is tested on CI against Ruby 2.4, 2.5, 2.7, 3.1, 3.2, 3.3, 3.4, 4.0 and JRuby 10.1.0.0. Ruby 2.4–3.1 remain in CI to verify compatibility with older ActiveRecord releases (see gemfiles/). The CI runs the suite against Oracle Database 23ai Free and Oracle Database XE 11g.
+ruby-plsql is tested on CI against Ruby 2.4, 2.5, 2.7, 3.1, 3.2, 3.3, 3.4, 4.0 and JRuby 10.1.1.0. Ruby 2.4–3.1 remain in CI to verify compatibility with older ActiveRecord releases (see gemfiles/). The CI runs the suite against Oracle Database 23ai Free and Oracle Database XE 11g.
 
 USAGE
 -----


### PR DESCRIPTION
This PR bumps the JRuby version used in CI (and the release workflow) from 10.1.0.0 to 10.1.1.0, and updates the README mention accordingly.

JRuby 10.1.1.0 was released on 2026-07-22: https://www.jruby.org/2026/07/22/jruby-10-1-1-0.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)